### PR TITLE
Check fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ AM_CFLAGS = -fstack-protector -Wall -pedantic \
         -Wformat -Wformat-security -Werror=format-security \
         -Wno-conversion -Wunused-variable -Wunreachable-code \
         -Wall -W -D_FORTIFY_SOURCE=2 \
-        -std=c99 -Werror \
+        -std=c99 \
         -DSYSCONFDIR=\"$(sysconfdir)\"
 
 AM_CPPFLAGS = \

--- a/test-init.sh
+++ b/test-init.sh
@@ -61,10 +61,12 @@ fi
 if [[ -e /usr/bin/goofiboot ]]; then
         cp /usr/bin/goofiboot "${top_builddir}/tests/dummy_install/usr/bin/."
         cp -R /usr/lib/goofiboot "${top_builddir}/tests/dummy_install/usr/lib/."
-elif [[ -e /usr/bin/gummiboot ]]; then
+fi
+if [[ -e /usr/bin/gummiboot ]]; then
         cp /usr/bin/gummiboot "${top_builddir}/tests/dummy_install/usr/bin/."
         cp -R /usr/lib/gummiboot "${top_builddir}/tests/dummy_install/usr/lib/."
-elif [[ -e /usr/bin/bootctl ]]; then
+fi
+if [[ -e /usr/bin/bootctl ]]; then
         cp /usr/bin/bootctl "${top_builddir}/tests/dummy_install/usr/bin/."
         mkdir -p "${top_builddir}/tests/dummy_install/usr/lib/systemd/boot/"
         cp -R /usr/lib/systemd/boot/efi "${top_builddir}/tests/dummy_install/usr/lib/systemd/boot"

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -244,7 +244,7 @@ START_TEST(bootman_install_bootloader_test)
         m = boot_manager_new();
         boot_manager_set_prefix(m, (char *)TOP_BUILD_DIR "/tests/dummy_install");
 
-        fail_if(!boot_manager_modify_bootloader(m, BOOTLOADER_OPERATION_INSTALL),
+        fail_if(!boot_manager_modify_bootloader(m, BOOTLOADER_OPERATION_INSTALL | BOOTLOADER_OPERATION_NO_CHECK),
                 "Failed to install the bootloader");
 
         if (boot_manager_get_architecture_size(m) == 64) {


### PR DESCRIPTION
This fixes the make check issues I can into on Clear Linux. Plus changes out Werror because it has outlived its usefulness.

The tests still fail by default though because of timeouts. This is caused by a lot of syncs being done in the purge test. I'm considering how to best make the syncs no ops in the check tests and while the best way is likely a dlopen and replace kind of workflow it may be a little much when we could just add a compile flag for check builds that causes sync to be replaced.

I'm open to ideas on that last point though.