### PR TITLE
Logging

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,8 @@ libcbm_la_SOURCES =			\
 	src/bootman/sysconfig.c		\
 	src/bootman/timeout.c		\
 	src/bootman/update.c		\
+	src/lib/log.h			\
+	src/lib/log.c			\
 	src/lib/util.h
 
 libcbm_la_CFLAGS =		\

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -121,8 +121,8 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
 
         root_uuid = boot_manager_get_root_uuid((BootManager *)manager);
         if (!root_uuid) {
-                /* But test suites. */
-                LOG_ERROR("PartUUID unknown, this should never happen! %s", kernel->path);
+                LOG_FATAL("PartUUID unknown, this should never happen! %s", kernel->path);
+                return false;
         }
 
         if (asprintf(&config_path, "%s/syslinux.cfg", base_path) < 0) {

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -25,6 +25,7 @@
 
 #include "bootloader.h"
 #include "files.h"
+#include "log.h"
 #include "nica/files.h"
 #include "util.h"
 
@@ -121,7 +122,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
         root_uuid = boot_manager_get_root_uuid((BootManager *)manager);
         if (!root_uuid) {
                 /* But test suites. */
-                LOG("PartUUID unknown, this should never happen! %s\n", kernel->path);
+                LOG_ERROR("PartUUID unknown, this should never happen! %s", kernel->path);
         }
 
         if (asprintf(&config_path, "%s/syslinux.cfg", base_path) < 0) {
@@ -204,9 +205,9 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
         }
 
         if (!file_set_text(config_path, config_text)) {
-                LOG("syslinux_set_default_kernel: Failed to write %s: %s\n",
-                    config_path,
-                    strerror(errno));
+                LOG_FATAL("syslinux_set_default_kernel: Failed to write %s: %s",
+                          config_path,
+                          strerror(errno));
                 return false;
         }
 

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -243,13 +243,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         /* Build the options for the entry */
         root_uuid = boot_manager_get_root_uuid((BootManager *)manager);
         if (!root_uuid) {
-                /* But test suites. */
-                LOG_ERROR("PartUUID unknown, this should never happen! %s", kernel->path);
-
-                if (!asprintf(&boot_options, "options %s", kernel->cmdline)) {
-                        DECLARE_OOM();
-                        abort();
-                }
+                LOG_FATAL("PartUUID unknown, this should never happen! %s", kernel->path);
+                return false;
         } else {
                 if (!asprintf(&boot_options,
                               "options root=PARTUUID=%s %s",

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -385,13 +385,10 @@ uint8_t boot_manager_get_platform_size(__cbm_unused__ BootManager *manager)
         close(fd);
 
         if (strncmp(buffer, "32", 2) == 0) {
-                LOG_DEBUG("Chosen 32-bit UEFI");
                 return 32;
         } else if (strncmp(buffer, "64", 2) == 0) {
-                LOG_DEBUG("Chosen 64-bit UEFI");
                 return 64;
         } else {
-                LOG_DEBUG("UEFI platform size unknown, resorting to 64-bit check");
                 return _detect_platform_size();
         }
 }

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -21,6 +21,7 @@
 #include "bootman.h"
 #include "bootman_private.h"
 #include "files.h"
+#include "log.h"
 #include "nica/files.h"
 
 #include "config.h"
@@ -47,7 +48,7 @@ BootManager *boot_manager_new()
         /* Try to parse the currently running kernel */
         if (uname(&uts) == 0) {
                 if (!boot_manager_set_uname(r, uts.release)) {
-                        fprintf(stderr, "Warning: Unable to parse kernel\n");
+                        LOG_WARNING("Unable to parse the currently running kernel");
                 }
         }
 
@@ -140,7 +141,7 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
         }
         if (!self->bootloader->init(self)) {
                 self->bootloader->destroy(self);
-                LOG("%s: Cannot initialise bootloader\n", __func__);
+                LOG_FATAL("%s: Cannot initialise bootloader", __func__);
                 return false;
         }
 
@@ -308,7 +309,7 @@ bool boot_manager_set_boot_dir(BootManager *self, const char *bootdir)
         if (!self->bootloader->init(self)) {
                 /* Ensure cleanup. */
                 self->bootloader->destroy(self);
-                FATAL("Re-initialisation of bootloader failed");
+                LOG_FATAL("Re-initialisation of bootloader failed");
                 return false;
         }
         return true;
@@ -345,7 +346,7 @@ bool boot_manager_modify_bootloader(BootManager *self, BootLoaderOperation op)
                 }
                 return true;
         } else {
-                LOG("boot_manager_modify_bootloader: Unknown operation\n");
+                LOG_FATAL("Unknown bootloader operation");
                 return false;
         }
 }
@@ -379,7 +380,7 @@ uint8_t boot_manager_get_platform_size(__cbm_unused__ BootManager *manager)
         }
 
         if (read(fd, buffer, sizeof(buffer)) != sizeof(buffer)) {
-                LOG("boot_manager_get_platform_size: Problematic firmware interface\n");
+                LOG_ERROR("Problematic firmware interface");
                 close(fd);
                 return _detect_platform_size();
         }

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -53,12 +53,6 @@ BootManager *boot_manager_new()
                 }
         }
 
-        /* Sane defaults. */
-        if (!boot_manager_set_prefix(r, "/")) {
-                boot_manager_free(r);
-                return NULL;
-        }
-
         /* Potentially consider a configure or os-release check */
         boot_manager_set_vendor_prefix(r, "Clear-linux");
         boot_manager_set_os_name(r, "Clear Linux Software for Intel Architecture");

--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -165,6 +165,8 @@ char *get_part_uuid(const char *path)
                 goto clean;
         }
 
+        LOG_DEBUG("UUID for %s is %s", node, value);
+
         ret = strdup(value);
 clean:
         blkid_free_probe(probe);

--- a/src/bootman/sysconfig.c
+++ b/src/bootman/sysconfig.c
@@ -20,6 +20,7 @@
 #include "bootman.h"
 #include "bootman_private.h"
 #include "files.h"
+#include "log.h"
 
 void cbm_free_sysconfig(SystemConfig *config)
 {
@@ -43,7 +44,7 @@ SystemConfig *cbm_inspect_root(const char *path)
 
         realp = realpath(path, NULL);
         if (!realp) {
-                LOG("Path specified does not exist: %s\n", path);
+                LOG_ERROR("Path specified does not exist: %s", path);
                 return NULL;
         }
 
@@ -55,7 +56,6 @@ SystemConfig *cbm_inspect_root(const char *path)
         }
         c->prefix = realp;
 
-        /* TODO: Disable logging */
         if (geteuid() == 0) {
                 char *rel = NULL;
 
@@ -71,9 +71,9 @@ SystemConfig *cbm_inspect_root(const char *path)
                 if (c->boot_device) {
                         rel = realpath(c->boot_device, NULL);
                         if (!rel) {
-                                LOG("FATAL: Cannot determine boot device: %s %s\n",
-                                    c->boot_device,
-                                    strerror(errno));
+                                LOG_FATAL("Cannot determine boot device: %s %s",
+                                          c->boot_device,
+                                          strerror(errno));
                         } else {
                                 free(c->boot_device);
                                 c->boot_device = rel;
@@ -88,11 +88,11 @@ SystemConfig *cbm_inspect_root(const char *path)
 bool cbm_is_sysconfig_sane(SystemConfig *config)
 {
         if (!config) {
-                LOG("sysconfig insane: Missing config\n");
+                LOG_FATAL("sysconfig insane: Missing config");
                 return false;
         }
         if (!config->root_uuid) {
-                LOG("sysconfig insane: Missing root_uuid\n");
+                LOG_FATAL("sysconfig insane: Missing root_uuid");
                 return false;
         }
         return true;

--- a/src/bootman/sysconfig.c
+++ b/src/bootman/sysconfig.c
@@ -64,6 +64,7 @@ SystemConfig *cbm_inspect_root(const char *path)
                 if (boot) {
                         c->boot_device = boot;
                         c->legacy = true;
+                        LOG_INFO("Discovered legacy boot device: %s", boot);
                 } else {
                         c->boot_device = get_boot_device();
                 }
@@ -77,6 +78,7 @@ SystemConfig *cbm_inspect_root(const char *path)
                         } else {
                                 free(c->boot_device);
                                 c->boot_device = rel;
+                                LOG_INFO("Discovered boot device: %s", rel);
                         }
                 }
                 c->root_uuid = get_part_uuid(realp);

--- a/src/bootman/timeout.c
+++ b/src/bootman/timeout.c
@@ -17,6 +17,7 @@
 
 #include "bootman.h"
 #include "bootman_private.h"
+#include "log.h"
 #include "nica/files.h"
 
 /**
@@ -44,7 +45,7 @@ bool boot_manager_set_timeout_value(BootManager *self, int timeout)
                         return true;
                 }
                 if (unlink(path) < 0) {
-                        fprintf(stderr, "Unable to remove %s: %s\n", path, strerror(errno));
+                        LOG_ERROR("Unable to remove %s: %s", path, strerror(errno));
                         return false;
                 }
                 return true;
@@ -52,12 +53,12 @@ bool boot_manager_set_timeout_value(BootManager *self, int timeout)
 
         fp = fopen(path, "w");
         if (!fp) {
-                fprintf(stderr, "Unable to open %s for writing: %s\n", path, strerror(errno));
+                LOG_FATAL("Unable to open %s for writing: %s", path, strerror(errno));
                 return false;
         }
 
         if (fprintf(fp, "%d\n", timeout) < 0) {
-                fprintf(stderr, "Unable to set new timeout: %s\n", strerror(errno));
+                LOG_FATAL("Unable to set new timeout: %s", strerror(errno));
                 return false;
         }
         return true;
@@ -85,12 +86,12 @@ int boot_manager_get_timeout_value(BootManager *self)
 
         fp = fopen(path, "r");
         if (!fp) {
-                fprintf(stderr, "Unable to open %s for reading: %s\n", path, strerror(errno));
+                LOG_FATAL("Unable to open %s for reading: %s", path, strerror(errno));
                 return -1;
         }
 
         if (fscanf(fp, "%d\n", &t_val) != 1) {
-                fprintf(stderr, "Failed to parse config file, defaulting to no timeout\n");
+                LOG_ERROR("Failed to parse config file, defaulting to no timeout");
                 return -1;
         }
 

--- a/src/cli/ops/timeout.c
+++ b/src/cli/ops/timeout.c
@@ -46,8 +46,15 @@ bool cbm_command_set_timeout(int argc, char **argv)
         }
 
         /* Use specified root if required */
-        if (root && !boot_manager_set_prefix(manager, root)) {
-                return false;
+        if (root) {
+                if (!boot_manager_set_prefix(manager, root)) {
+                        return false;
+                }
+        } else {
+                /* Default to "/", bail if it doesn't work. */
+                if (!boot_manager_set_prefix(manager, "/")) {
+                        return false;
+                }
         }
 
         if (argc != 1) {
@@ -99,8 +106,15 @@ bool cbm_command_get_timeout(int argc, char **argv)
         }
 
         /* Use specified root if required */
-        if (root && !boot_manager_set_prefix(manager, root)) {
-                return false;
+        if (root) {
+                if (!boot_manager_set_prefix(manager, root)) {
+                        return false;
+                }
+        } else {
+                /* Default to "/", bail if it doesn't work. */
+                if (!boot_manager_set_prefix(manager, "/")) {
+                        return false;
+                }
         }
 
         if (argc != 0) {

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -58,6 +58,11 @@ bool cbm_command_update(int argc, char **argv)
                 if (!boot_manager_set_prefix(manager, root)) {
                         return false;
                 }
+        } else {
+                /* Default to "/", bail if it doesn't work. */
+                if (!boot_manager_set_prefix(manager, "/")) {
+                        return false;
+                }
         }
 
         if (forced_image) {

--- a/src/cli/ops/update.c
+++ b/src/cli/ops/update.c
@@ -18,6 +18,7 @@
 
 #include "bootman.h"
 #include "cli.h"
+#include "log.h"
 
 bool cbm_command_update(int argc, char **argv)
 {
@@ -44,7 +45,8 @@ bool cbm_command_update(int argc, char **argv)
 
                 realp = realpath(root, NULL);
                 if (!realp) {
-                        LOG("Path specified does not exist: %s\n", root);
+                        LOG_FATAL("Path specified does not exist: %s", root);
+                        return false;
                 }
                 /* Anything not / is image mode */
                 if (!streq(realp, "/")) {

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -23,11 +23,9 @@ static CbmLogLevel min_log_level;
 
 #define PACKAGE_NAME_SHORT "cbm"
 
-static const char *log_str_table[] = {[CBM_LOG_DEBUG] = "DEBUG",
-                                      [CBM_LOG_INFO] = "INFO",
-                                      [CBM_LOG_SUCCESS] = "SUCCESS",
-                                      [CBM_LOG_ERROR] = "ERROR",
-                                      [CBM_LOG_FATAL] = "FATAL" };
+static const char *log_str_table[] = {[CBM_LOG_DEBUG] = "DEBUG",     [CBM_LOG_INFO] = "INFO",
+                                      [CBM_LOG_SUCCESS] = "SUCCESS", [CBM_LOG_ERROR] = "ERROR",
+                                      [CBM_LOG_WARNING] = "WARNING", [CBM_LOG_FATAL] = "FATAL" };
 
 void cbm_log_init(FILE *log)
 {
@@ -49,6 +47,8 @@ void cbm_log_init(FILE *log)
         } else if (streq(env_level, "4")) {
                 min_log_level = CBM_LOG_ERROR;
         } else if (streq(env_level, "5")) {
+                min_log_level = CBM_LOG_WARNING;
+        } else if (streq(env_level, "6")) {
                 min_log_level = CBM_LOG_FATAL;
         } else {
                 min_log_level = CBM_LOG_ERROR;

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -1,0 +1,121 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "log.h"
+#include "nica/util.h"
+
+static FILE *log_file = NULL;
+static CbmLogLevel min_log_level;
+
+#define PACKAGE_NAME_SHORT "cbm"
+
+static const char *log_str_table[] = {[CBM_LOG_DEBUG] = "DEBUG",
+                                      [CBM_LOG_INFO] = "INFO",
+                                      [CBM_LOG_SUCCESS] = "SUCCESS",
+                                      [CBM_LOG_ERROR] = "ERROR",
+                                      [CBM_LOG_FATAL] = "FATAL" };
+
+void cbm_log_init(FILE *log)
+{
+        const char *env_level = NULL;
+        log_file = log;
+
+        env_level = getenv("CBM_DEBUG");
+        if (!env_level) {
+                min_log_level = CBM_LOG_ERROR;
+                return;
+        }
+
+        if (streq(env_level, "1")) {
+                min_log_level = CBM_LOG_DEBUG;
+        } else if (streq(env_level, "2")) {
+                min_log_level = CBM_LOG_INFO;
+        } else if (streq(env_level, "3")) {
+                min_log_level = CBM_LOG_SUCCESS;
+        } else if (streq(env_level, "4")) {
+                min_log_level = CBM_LOG_ERROR;
+        } else if (streq(env_level, "5")) {
+                min_log_level = CBM_LOG_FATAL;
+        } else {
+                min_log_level = CBM_LOG_ERROR;
+        }
+}
+
+/**
+ * Ensure we're always at least initialised with stderr
+ */
+__attribute__((constructor)) static void cbm_log_first_init(void)
+{
+        cbm_log_init(stderr);
+}
+
+static inline const char *cbm_log_level_str(CbmLogLevel l)
+{
+        if (l >= 0 && l <= CBM_LOG_FATAL) {
+                return log_str_table[l];
+        }
+        return "unknown";
+}
+
+void cbm_log(CbmLogLevel level, const char *filename, int lineno, const char *format, ...)
+{
+        const char *displ = NULL;
+        va_list vargs;
+        autofree(char) *rend = NULL;
+
+        /* Respect minimum log level */
+        if (level < min_log_level) {
+                return;
+        }
+
+        displ = cbm_log_level_str(level);
+
+        va_start(vargs, format);
+
+        if (vasprintf(&rend, format, vargs) < 0) {
+                fputs("[FATAL] " PACKAGE_NAME_SHORT ": Cannot log to stream", log_file);
+                goto clean_args;
+        }
+
+        if (fprintf(log_file,
+                    "[%s] %s (%s:L%d): %s\n",
+                    displ,
+                    PACKAGE_NAME_SHORT,
+                    filename,
+                    lineno,
+                    rend) < 0) {
+                /* Forcibly fall back to stderr with the error */
+                fputs("[FATAL] " PACKAGE_NAME_SHORT ": Cannot log to stream", stderr);
+                goto clean_args;
+        }
+
+clean_args:
+        va_end(vargs);
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -20,6 +20,7 @@ typedef enum {
         CBM_LOG_INFO,
         CBM_LOG_SUCCESS,
         CBM_LOG_ERROR,
+        CBM_LOG_WARNING,
         CBM_LOG_FATAL
 } CbmLogLevel;
 
@@ -62,6 +63,11 @@ void cbm_log(CbmLogLevel level, const char *file, int line, const char *format, 
  * Log a fatal error
  */
 #define LOG_FATAL(...) (cbm_log(CBM_LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__))
+
+/**
+ * Log a warning message that must always be seen
+ */
+#define LOG_WARNING(...) (cbm_log(CBM_LOG_WARNING, __FILE__, __LINE__, __VA_ARGS__))
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/lib/log.h
+++ b/src/lib/log.h
@@ -1,0 +1,77 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+
+typedef enum {
+        CBM_LOG_DEBUG = 0,
+        CBM_LOG_INFO,
+        CBM_LOG_SUCCESS,
+        CBM_LOG_ERROR,
+        CBM_LOG_FATAL
+} CbmLogLevel;
+
+/**
+ * Re-initialise the logging functionality, to use a different file descriptor
+ * for logging
+ *
+ * @note This is already called once with stderr as the log file
+ */
+void cbm_log_init(FILE *log);
+
+/**
+ * Log current status/error to stderr. It is recommended to use the
+ * macros to achieve this.
+ */
+void cbm_log(CbmLogLevel level, const char *file, int line, const char *format, ...)
+    __attribute__((format(printf, 4, 5)));
+
+/**
+ * Log a simple debug message
+ */
+#define LOG_DEBUG(...) (cbm_log(CBM_LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__))
+
+/**
+ * Log an informational message
+ */
+#define LOG_INFO(...) (cbm_log(CBM_LOG_INFO, __FILE__, __LINE__, __VA_ARGS__))
+
+/**
+ * Log success
+ */
+#define LOG_SUCCESS(...) (cbm_log(CBM_LOG_SUCCESS, __FILE__, __LINE__, __VA_ARGS__))
+
+/**
+ * Log a non-fatal error
+ */
+#define LOG_ERROR(...) (cbm_log(CBM_LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__))
+
+/**
+ * Log a fatal error
+ */
+#define LOG_FATAL(...) (cbm_log(CBM_LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__))
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -20,15 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/** Revisit in future */
-#define LOG(...) fprintf(stderr, __VA_ARGS__)
-
-#define FATAL(...)                                                                                 \
-        do {                                                                                       \
-                fprintf(stderr, "%s()[%d]: %s\n", __func__, __LINE__, __VA_ARGS__);                \
-        } while (0);
-
-#define DECLARE_OOM() FATAL("Out Of Memory")
+#define DECLARE_OOM() (fputs("Out of memory", stderr))
 
 #define OOM_CHECK(x)                                                                               \
         {                                                                                          \

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -18,6 +18,7 @@
 #include "bootman.h"
 #include "config.h"
 #include "files.h"
+#include "log.h"
 #include "nica/array.h"
 #include "nica/files.h"
 #include "util.h"
@@ -534,6 +535,10 @@ int main(void)
 
         /* syncing can be problematic during test suite runs */
         cbm_set_sync_filesystems(false);
+
+        /* Ensure that logging is set up properly. */
+        setenv("CBM_DEBUG", "1", 1);
+        cbm_log_init(stderr);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/check-files.c
+++ b/tests/check-files.c
@@ -19,6 +19,7 @@
 #include "util.h"
 
 #include "files.h"
+#include "log.h"
 #include "nica/files.h"
 
 START_TEST(bootman_hash_test)
@@ -39,7 +40,7 @@ END_TEST
 START_TEST(bootman_uuid_test)
 {
         if (geteuid() != 0) {
-                LOG("Skipping UUID test as root privileges are required\n");
+                LOG_INFO("Skipping UUID test as root privileges are required");
                 return;
         }
         const char *path = TOP_DIR "/tests/data/hashfile";
@@ -48,14 +49,14 @@ START_TEST(bootman_uuid_test)
         puuid = get_part_uuid(path);
         fail_if(!puuid, "Failed to get filesystem UUID");
 
-        LOG("PUUID: %s\n", puuid);
+        LOG_INFO("PUUID: %s", puuid);
 }
 END_TEST
 
 START_TEST(bootman_find_boot)
 {
         if (!nc_file_exists("/sys/firmware/efi")) {
-                LOG("Skipping UEFI host-specific test\n");
+                LOG_INFO("Skipping UEFI host-specific test");
                 return;
         }
         autofree(char) *boot = NULL;
@@ -68,7 +69,7 @@ END_TEST
 START_TEST(bootman_mount_test)
 {
         if (!nc_file_exists("/proc/self/mounts")) {
-                LOG("Skipping mount test as /proc/self/mounts is absent");
+                LOG_INFO("Skipping mount test as /proc/self/mounts is absent");
                 return;
         }
         fail_if(!cbm_is_mounted("/", NULL), "Apparently / not mounted. Question physics.");
@@ -101,6 +102,10 @@ int main(void)
 
         /* syncing can be problematic during test suite runs */
         cbm_set_sync_filesystems(false);
+
+        /* Ensure that logging is set up properly. */
+        setenv("CBM_DEBUG", "1", 1);
+        cbm_log_init(stderr);
 
         s = core_suite();
         sr = srunner_create(s);

--- a/tests/check-updates.c
+++ b/tests/check-updates.c
@@ -21,6 +21,7 @@
 
 #include "bootman.h"
 #include "files.h"
+#include "log.h"
 #include "nica/files.h"
 
 #include "config.h"
@@ -285,6 +286,10 @@ int main(void)
 
         /* syncing can be problematic during test suite runs */
         cbm_set_sync_filesystems(false);
+
+        /* Ensure that logging is set up properly. */
+        setenv("CBM_DEBUG", "1", 1);
+        cbm_log_init(stderr);
 
         s = core_suite();
         sr = srunner_create(s);


### PR DESCRIPTION
This change is mostly about enabling devops to run CBM with CBM_DEBUG=1 in the environment for debugging purposes. It also introduces some consistency cleanups and forgotten fixes for items that previously changed (double-probe and mandatory UUID)