### PR TITLE
Ignore leaks in sockets.

### DIFF
--- a/src/nica/util.c
+++ b/src/nica/util.c
@@ -69,7 +69,7 @@ void nc_dump_file_descriptor_leaks(void)
 
                 memset(&buffer, 0, sizeof(buffer));
                 size = readlink(filename, buffer, PATH_MAX);
-                if (size) {
+                if (size && !strstr(buffer, "socket")) {
                         fprintf(stderr,
                                 "Possible filedescriptor leak : %s (%s)\n",
                                 entry->d_name,


### PR DESCRIPTION
The only sockets held are irrelevant for our file descriptor
leak check, which focuses on leaks in opening/closing regular
files. Some of the sockets are things like pacrunner that
curl opens, and we should just ignore leaks in them.

Copied from my change in swupd-client v3.6.5