### PR TITLE
Remove OpenSSL & Cleanup Code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
         packages:
             - check
             - libblkid-dev
-            - libssl-dev
             - valgrind
             - lcov
             - clang-3.8

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,6 @@ EXTRA_DIST = ${top_srcdir}/README.md \
 	     ${top_srcdir}/LICENSE.LGPL2.1 \
 	     ${top_srcdir}/HACKING \
 	     ${top_srcdir}/findstatic.pl \
-	     ${top_srcdir}/tests/data/hashfile \
 	     ${top_srcdir}/tests/data/blobfile \
 	     ${top_srcdir}/sgcheck.suppressions \
 	     ${top_srcdir}/data/clr-boot-manager-booted.service \
@@ -110,7 +109,6 @@ libcbm_la_SOURCES =			\
 
 libcbm_la_CFLAGS =		\
 	-D_BOOTMAN_INTERNAL_	\
-	$(CRYPTO_CFLAGS)	\
 	$(BLKID_CFLAGS)		\
 	$(AM_CFLAGS)
 
@@ -129,14 +127,12 @@ clr_boot_manager_SOURCES =		\
 	src/cli/main.c
 
 clr_boot_manager_CFLAGS =	\
-	$(CRYPTO_CFLAGS)	\
 	$(BLKID_CFLAGS)		\
 	$(AM_CFLAGS)
 
 clr_boot_manager_LDADD =	\
 	libcbm.la		\
 	libnica.la		\
-	$(CRYPTO_LIBS)		\
 	$(BLKID_LIBS)
 
 install-exec-hook:
@@ -168,7 +164,6 @@ check_core_SOURCES =		\
 	tests/harness.c
 
 check_core_CFLAGS =		\
-	$(CRYPTO_CFLAGS)	\
 	$(BLKID_CFLAGS)		\
 	$(CHECK_CFLAGS)		\
 	$(AM_CFLAGS)
@@ -176,7 +171,6 @@ check_core_CFLAGS =		\
 check_core_LDADD =	\
 	libcbm.la	\
 	libnica.la	\
-	$(CRYPTO_LIBS)	\
 	$(BLKID_LIBS)	\
 	$(CHECK_LIBS)
 
@@ -184,7 +178,6 @@ check_files_SOURCES = \
 	tests/check-files.c
 
 check_files_CFLAGS =		\
-	$(CRYPTO_CFLAGS)	\
 	$(BLKID_CFLAGS)		\
 	$(CHECK_CFLAGS)		\
 	$(AM_CFLAGS)
@@ -192,7 +185,6 @@ check_files_CFLAGS =		\
 check_files_LDADD =	\
 	libcbm.la	\
 	libnica.la	\
-	$(CRYPTO_LIBS)	\
 	$(BLKID_LIBS)	\
 	$(CHECK_LIBS)
 
@@ -202,7 +194,6 @@ check_updates_SOURCES =		\
 	tests/harness.c
 
 check_updates_CFLAGS =		\
-	$(CRYPTO_CFLAGS)	\
 	$(BLKID_CFLAGS)		\
 	$(CHECK_CFLAGS)		\
 	$(AM_CFLAGS)
@@ -210,7 +201,6 @@ check_updates_CFLAGS =		\
 check_updates_LDADD =	\
 	libcbm.la	\
 	libnica.la	\
-	$(CRYPTO_LIBS)	\
 	$(BLKID_LIBS)	\
 	$(CHECK_LIBS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,10 @@ EXTRA_DIST = ${top_srcdir}/README.md \
 	     ${top_srcdir}/HACKING \
 	     ${top_srcdir}/findstatic.pl \
 	     ${top_srcdir}/tests/data/blobfile \
+	     ${top_srcdir}/tests/data/match \
+	     ${top_srcdir}/tests/data/match1 \
+	     ${top_srcdir}/tests/data/nomatch1 \
+	     ${top_srcdir}/tests/data/nomatch2 \
 	     ${top_srcdir}/sgcheck.suppressions \
 	     ${top_srcdir}/data/clr-boot-manager-booted.service \
 	     ${top_srcdir}/compat/kernel_updater.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,6 @@ LT_INIT
 
 # Unit tests
 PKG_CHECK_MODULES([CHECK], [check >= 0.9])
-PKG_CHECK_MODULES([CRYPTO], [libcrypto >= 0.9.8])
 PKG_CHECK_MODULES([BLKID], [blkid])
 
 have_coverage=no

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -172,19 +172,17 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                                 abort();
                         }
                 }
-                if (streq(k->path, kernel->path)) {
+                if (kernel && streq(k->path, kernel->path)) {
                         if (asprintf(&default_text, "DEFAULT %s\n", kname_base) < 0) {
                                 DECLARE_OOM();
                                 abort();
                         }
-                } else {
-                        default_text = "";
                 }
 
                 if (asprintf(&config_text,
                              "%s%sLABEL %s\n  KERNEL %s\n  APPEND %s\n",
                              _config_text,
-                             default_text,
+                             default_text ? default_text : "",
                              kname_base,
                              kname_base,
                              boot_options) < 0) {
@@ -196,7 +194,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 kname_copy = NULL;
                 free(boot_options);
                 boot_options = NULL;
-                if (streq(k->path, kernel->path)) {
+                if (default_text) {
                         free(default_text);
                 }
                 default_text = NULL;

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -95,7 +95,8 @@ bool sd_class_init(const BootManager *manager, BootLoaderConfig *config)
         prefix = boot_manager_get_prefix((BootManager *)manager);
 
         /* ia32 paths */
-        if (!asprintf(&ia32_source, "%s/%s/%s", prefix, sd_config->efi_dir, sd_config->ia32_blob)) {
+        if (asprintf(&ia32_source, "%s/%s/%s", prefix, sd_config->efi_dir, sd_config->ia32_blob) <
+            0) {
                 sd_class_destroy(manager);
                 DECLARE_OOM();
                 return false;
@@ -111,7 +112,8 @@ bool sd_class_init(const BootManager *manager, BootLoaderConfig *config)
         sd_class_config.ia32_dest = ia32_dest;
 
         /* x64 paths */
-        if (!asprintf(&x64_source, "%s/%s/%s", prefix, sd_config->efi_dir, sd_config->x64_blob)) {
+        if (asprintf(&x64_source, "%s/%s/%s", prefix, sd_config->efi_dir, sd_config->x64_blob) <
+            0) {
                 sd_class_destroy(manager);
                 DECLARE_OOM();
                 return false;
@@ -179,12 +181,12 @@ static char *get_entry_path_for_kernel(BootManager *manager, const Kernel *kerne
 
         prefix = boot_manager_get_vendor_prefix(manager);
 
-        if (!asprintf(&item_name,
-                      "%s-%s-%s-%d.conf",
-                      prefix,
-                      kernel->ktype,
-                      kernel->version,
-                      kernel->release)) {
+        if (asprintf(&item_name,
+                     "%s-%s-%s-%d.conf",
+                     prefix,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -246,10 +248,10 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                 LOG_FATAL("PartUUID unknown, this should never happen! %s", kernel->path);
                 return false;
         } else {
-                if (!asprintf(&boot_options,
-                              "options root=PARTUUID=%s %s",
-                              root_uuid,
-                              kernel->cmdline)) {
+                if (asprintf(&boot_options,
+                             "options root=PARTUUID=%s %s",
+                             root_uuid,
+                             kernel->cmdline) < 0) {
                         DECLARE_OOM();
                         abort();
                 }
@@ -261,11 +263,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         os_name = boot_manager_get_os_name((BootManager *)manager);
 
         /* Kernels are installed to the root of the ESP, namespaced */
-        if (!asprintf(&conf_entry,
-                      "title %s\nlinux /%s\n%s\n",
-                      os_name,
-                      kname_base,
-                      boot_options)) {
+        if (asprintf(&conf_entry, "title %s\nlinux /%s\n%s\n", os_name, kname_base, boot_options) <
+            0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -343,23 +342,23 @@ bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kerne
 
         if (timeout > 0) {
                 /* Set the timeout as configured by the user */
-                if (!asprintf(&item_name,
-                              "timeout %d\ndefault %s-%s-%s-%d\n\n",
-                              timeout,
-                              prefix,
-                              kernel->ktype,
-                              kernel->version,
-                              kernel->release)) {
+                if (asprintf(&item_name,
+                             "timeout %d\ndefault %s-%s-%s-%d\n\n",
+                             timeout,
+                             prefix,
+                             kernel->ktype,
+                             kernel->version,
+                             kernel->release) < 0) {
                         DECLARE_OOM();
                         return false;
                 }
         } else {
-                if (!asprintf(&item_name,
-                              "default %s-%s-%s-%d\n",
-                              prefix,
-                              kernel->ktype,
-                              kernel->version,
-                              kernel->release)) {
+                if (asprintf(&item_name,
+                             "default %s-%s-%s-%d\n",
+                             prefix,
+                             kernel->ktype,
+                             kernel->version,
+                             kernel->release) < 0) {
                         DECLARE_OOM();
                         return false;
                 }

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -106,7 +106,7 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
                 self->kernel_dir = NULL;
         }
 
-        if (!asprintf(&kernel_dir, "%s/%s", config->prefix, KERNEL_DIRECTORY)) {
+        if (asprintf(&kernel_dir, "%s/%s", config->prefix, KERNEL_DIRECTORY) < 0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -277,7 +277,7 @@ char *boot_manager_get_boot_dir(BootManager *self)
                 return strdup(self->abs_bootdir);
         }
 
-        if (!asprintf(&ret, "%s%s", self->sysconfig->prefix, BOOT_DIRECTORY)) {
+        if (asprintf(&ret, "%s%s", self->sysconfig->prefix, BOOT_DIRECTORY) < 0) {
                 DECLARE_OOM();
                 abort();
         }

--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -97,7 +97,7 @@ char *get_part_uuid(const char *path)
                 return NULL;
         }
 
-        if (!asprintf(&node, "/dev/block/%u:%u", major(st.st_dev), minor(st.st_dev))) {
+        if (asprintf(&node, "/dev/block/%u:%u", major(st.st_dev), minor(st.st_dev)) < 0) {
                 DECLARE_OOM();
                 return NULL;
         }
@@ -182,7 +182,7 @@ char *get_boot_device()
         }
         read_buf[j] = '\0';
 
-        if (!asprintf(&p, "/dev/disk/by-partuuid/%s", uuid)) {
+        if (asprintf(&p, "/dev/disk/by-partuuid/%s", uuid) < 0) {
                 DECLARE_OOM();
                 return NULL;
         }
@@ -232,7 +232,7 @@ char *get_parent_disk(char *path)
                 return NULL;
         }
 
-        if (!asprintf(&node, "/dev/block/%u:%u", major(devt), minor(devt))) {
+        if (asprintf(&node, "/dev/block/%u:%u", major(devt), minor(devt)) < 0) {
                 DECLARE_OOM();
                 return NULL;
         }
@@ -289,7 +289,7 @@ char *get_legacy_boot_device(char *path)
                                 LOG_ERROR("Not a valid GPT disk");
                                 goto clean;
                         }
-                        if (!asprintf(&pt_path, "/dev/disk/by-partuuid/%s", part_id)) {
+                        if (asprintf(&pt_path, "/dev/disk/by-partuuid/%s", part_id) < 0) {
                                 DECLARE_OOM();
                                 goto clean;
                         }
@@ -415,7 +415,7 @@ bool copy_file_atomic(const char *src, const char *target, mode_t mode)
         autofree(char) *new_name = NULL;
         struct stat st = { 0 };
 
-        if (!asprintf(&new_name, "%s.TmpWrite", target)) {
+        if (asprintf(&new_name, "%s.TmpWrite", target) < 0) {
                 return false;
         }
 

--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -20,7 +20,6 @@
 #include <glob.h>
 #include <libgen.h>
 #include <limits.h>
-#include <openssl/sha.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -53,54 +52,6 @@ void cbm_sync(void)
         if (cbm_should_sync) {
                 sync();
         }
-}
-
-char *get_sha1sum(const char *p)
-{
-        unsigned char hash[SHA_DIGEST_LENGTH] = { 0 };
-        int fd = -1;
-        struct stat st = { 0 };
-        char *buffer = NULL;
-        char *ret = NULL;
-        size_t max_len = SHA_DIGEST_LENGTH * 2;
-        size_t st_size;
-
-        if ((fd = open(p, O_RDONLY)) < 0) {
-                goto finish;
-        }
-        if (fstat(fd, &st) < 0) {
-                goto finish;
-        }
-
-        st_size = (size_t)st.st_size;
-
-        buffer = mmap(0, st_size, PROT_READ, MAP_PRIVATE, fd, 0);
-        if (!buffer) {
-                goto finish;
-        }
-
-        if (!SHA1((unsigned char *)buffer, st_size, hash)) {
-                goto finish;
-        }
-
-        ret = calloc((max_len) + 1, sizeof(char));
-        if (!ret) {
-                goto finish;
-        }
-
-        for (int i = 0; i < SHA_DIGEST_LENGTH; i++) {
-                snprintf(ret + (i * 2), max_len, "%02x", hash[i]);
-        }
-        ret[max_len] = '\0';
-
-finish:
-        if (fd >= 0) {
-                close(fd);
-        }
-        if (buffer) {
-                munmap(buffer, st_size);
-        }
-        return ret;
 }
 
 bool cbm_files_match(const char *p1, const char *p2)

--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -105,19 +105,27 @@ finish:
 
 bool cbm_files_match(const char *p1, const char *p2)
 {
-        autofree(char) *h1 = NULL;
-        autofree(char) *h2 = NULL;
+        autofree(CbmMappedFile) *m1 = CBM_MAPPED_FILE_INIT;
+        autofree(CbmMappedFile) *m2 = CBM_MAPPED_FILE_INIT;
 
-        h1 = get_sha1sum(p1);
-        if (!h1) {
-                return false;
-        }
-        h2 = get_sha1sum(p2);
-        if (!h2) {
+        if (!cbm_mapped_file_open(p1, m1)) {
                 return false;
         }
 
-        return streq(h1, h2);
+        if (!cbm_mapped_file_open(p2, m2)) {
+                return false;
+        }
+
+        /* If the lengths are different they're clearly not the same file */
+        if (m1->length != m2->length) {
+                return false;
+        }
+
+        /* Compare both buffers */
+        if (memcmp(m1->buffer, m2->buffer, m1->length) == 0) {
+                return true;
+        }
+        return false;
 }
 
 char *get_part_uuid(const char *path)

--- a/src/bootman/files.h
+++ b/src/bootman/files.h
@@ -39,14 +39,6 @@ typedef struct CbmMappedFile {
 } CbmMappedFile;
 
 /**
- * Get the SHA-1 hashsum for the given path as a hex string
- *
- * @param path Path of the file to hash
- * @return a newly allocated string, or NULL on error
- */
-char *get_sha1sum(const char *path);
-
-/**
  * Get the PartUUID for a given path
  *
  * @param path Path to get the PartUUID for

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -79,12 +79,12 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         }
 
         parent = cbm_get_file_parent(path);
-        if (!asprintf(&cmdline, "%s/cmdline-%s-%d.%s", parent, version, release, type)) {
+        if (asprintf(&cmdline, "%s/cmdline-%s-%d.%s", parent, version, release, type) < 0) {
                 DECLARE_OOM();
                 abort();
         }
 
-        if (!asprintf(&kconfig_file, "%s/config-%s-%d.%s", parent, version, release, type)) {
+        if (asprintf(&kconfig_file, "%s/config-%s-%d.%s", parent, version, release, type) < 0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -98,13 +98,13 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         }
 
         /* Check local modules */
-        if (!asprintf(&module_dir,
-                      "%s/%s/%s-%d.%s",
-                      self->sysconfig->prefix,
-                      KERNEL_MODULES_DIRECTORY,
-                      version,
-                      release,
-                      type)) {
+        if (asprintf(&module_dir,
+                     "%s/%s/%s-%d.%s",
+                     self->sysconfig->prefix,
+                     KERNEL_MODULES_DIRECTORY,
+                     version,
+                     release,
+                     type) < 0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -112,12 +112,12 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         /* Fallback to an older namespace */
         if (!nc_file_exists(module_dir)) {
                 free(module_dir);
-                if (!asprintf(&module_dir,
-                              "%s/%s/%s-%d",
-                              self->sysconfig->prefix,
-                              KERNEL_MODULES_DIRECTORY,
-                              version,
-                              release)) {
+                if (asprintf(&module_dir,
+                             "%s/%s/%s-%d",
+                             self->sysconfig->prefix,
+                             KERNEL_MODULES_DIRECTORY,
+                             version,
+                             release) < 0) {
                         DECLARE_OOM();
                         abort();
                 }
@@ -159,7 +159,7 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
                         buf[r - 1] = '\0';
                 }
                 if (kern->cmdline) {
-                        if (!asprintf(&tmp, "%s %s", kern->cmdline, buf)) {
+                        if (asprintf(&tmp, "%s %s", kern->cmdline, buf) < 0) {
                                 DECLARE_OOM();
                                 abort();
                         }
@@ -209,7 +209,7 @@ KernelArray *boot_manager_get_kernels(BootManager *self)
                 autofree(char) *path = NULL;
                 Kernel *kern = NULL;
 
-                if (!asprintf(&path, "%s/%s", self->kernel_dir, ent->d_name)) {
+                if (asprintf(&path, "%s/%s", self->kernel_dir, ent->d_name) < 0) {
                         DECLARE_OOM();
                         abort();
                 }
@@ -500,7 +500,7 @@ bool boot_manager_is_kernel_installed_internal(const BootManager *manager, const
         }
         kname_base = basename(path);
 
-        if (!asprintf(&path2, "%s/%s", base_path, kname_base)) {
+        if (asprintf(&path2, "%s/%s", base_path, kname_base) < 0) {
                 DECLARE_OOM();
                 abort();
         }
@@ -529,7 +529,7 @@ bool boot_manager_install_kernel_internal(const BootManager *manager, const Kern
         kname_base = basename(kname_copy);
 
         /* Now copy the kernel file to it's new location */
-        if (!asprintf(&kfile_target, "%s/%s", base_path, kname_base)) {
+        if (asprintf(&kfile_target, "%s/%s", base_path, kname_base) < 0) {
                 DECLARE_OOM();
                 return false;
         }
@@ -562,7 +562,7 @@ bool boot_manager_remove_kernel_internal(const BootManager *manager, const Kerne
         kname_copy = strdup(kernel->path);
         kname_base = basename(kname_copy);
 
-        if (!asprintf(&kfile_target, "%s/%s", base_path, kname_base)) {
+        if (asprintf(&kfile_target, "%s/%s", base_path, kname_base) < 0) {
                 DECLARE_OOM();
                 return false;
         }

--- a/src/bootman/timeout.c
+++ b/src/bootman/timeout.c
@@ -34,7 +34,7 @@ bool boot_manager_set_timeout_value(BootManager *self, int timeout)
                 return false;
         }
 
-        if (!asprintf(&path, "%s%s", self->sysconfig->prefix, BOOT_TIMEOUT_CONFIG)) {
+        if (asprintf(&path, "%s%s", self->sysconfig->prefix, BOOT_TIMEOUT_CONFIG) < 0) {
                 DECLARE_OOM();
                 return -1;
         }
@@ -74,7 +74,7 @@ int boot_manager_get_timeout_value(BootManager *self)
                 return false;
         }
 
-        if (!asprintf(&path, "%s%s", self->sysconfig->prefix, BOOT_TIMEOUT_CONFIG)) {
+        if (asprintf(&path, "%s%s", self->sysconfig->prefix, BOOT_TIMEOUT_CONFIG) < 0) {
                 DECLARE_OOM();
                 return -1;
         }

--- a/src/nica/files.c
+++ b/src/nica/files.c
@@ -157,7 +157,7 @@ char *nc_build_case_correct_path_va(const char *c, va_list ap)
                 } else {
                         sav = strdup(root);
 
-                        if (!asprintf(&t, "%s/%s", root, p)) {
+                        if (asprintf(&t, "%s/%s", root, p) < 0) {
                                 fprintf(stderr,
                                         "nc_build_case_correct_path_va: Out "
                                         "of memory\n");
@@ -197,7 +197,7 @@ char *nc_build_case_correct_path_va(const char *c, va_list ap)
                         }
                         if (strcasecmp(ent->d_name, p) == 0) {
                                 if (sav) {
-                                        if (!asprintf(&t, "%s/%s", sav, ent->d_name)) {
+                                        if (asprintf(&t, "%s/%s", sav, ent->d_name) < 0) {
                                                 fprintf(stderr,
                                                         "nc_build_case_"
                                                         "correct_path_va: Out "

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -58,7 +58,7 @@ START_TEST(bootman_memory_test)
         {
                 autofree(memtestchar) *tmp = NULL;
 
-                if (!asprintf(&tmp, "Allocation test")) {
+                if (asprintf(&tmp, "Allocation test") < 0) {
                         fail("Unable to allocate memory");
                 }
         }
@@ -259,19 +259,19 @@ START_TEST(bootman_install_kernel_test)
 
         fail_if(!boot_manager_install_kernel(m, kernel), "Failed to install kernel");
 
-        if (!asprintf(&path1,
-                      "%s/tests/update_playground/%s/loader/entries/%s-native-4.2.3-138.conf",
-                      TOP_BUILD_DIR,
-                      BOOT_DIRECTORY,
-                      vendor)) {
+        if (asprintf(&path1,
+                     "%s/tests/update_playground/%s/loader/entries/%s-native-4.2.3-138.conf",
+                     TOP_BUILD_DIR,
+                     BOOT_DIRECTORY,
+                     vendor) < 0) {
                 abort();
         }
 
-        if (!asprintf(&path2,
-                      "%s/tests/update_playground/%s/%s.native.4.2.3-138",
-                      TOP_BUILD_DIR,
-                      BOOT_DIRECTORY,
-                      KERNEL_NAMESPACE)) {
+        if (asprintf(&path2,
+                     "%s/tests/update_playground/%s/%s.native.4.2.3-138",
+                     TOP_BUILD_DIR,
+                     BOOT_DIRECTORY,
+                     KERNEL_NAMESPACE) < 0) {
                 abort();
         }
 
@@ -291,9 +291,9 @@ START_TEST(bootman_set_default_kernel_test)
 
         m = prepare_playground(&core_config);
 
-        if (!asprintf(&expected,
-                      "default %s-native-4.2.3-138\n",
-                      boot_manager_get_vendor_prefix(m))) {
+        if (asprintf(&expected,
+                     "default %s-native-4.2.3-138\n",
+                     boot_manager_get_vendor_prefix(m)) < 0) {
                 abort();
         }
 
@@ -335,19 +335,19 @@ START_TEST(bootman_remove_kernel_test)
 
         fail_if(!boot_manager_remove_kernel(m, kernel), "Failed to remove kernel");
 
-        if (!asprintf(&path1,
-                      "%s/tests/update_playground/%s/loader/entries/%s-native-4.2.3-138.conf",
-                      TOP_BUILD_DIR,
-                      BOOT_DIRECTORY,
-                      os_name)) {
+        if (asprintf(&path1,
+                     "%s/tests/update_playground/%s/loader/entries/%s-native-4.2.3-138.conf",
+                     TOP_BUILD_DIR,
+                     BOOT_DIRECTORY,
+                     os_name) < 0) {
                 abort();
         }
 
-        if (!asprintf(&path2,
-                      "%s/tests/update_playground/%s/%s.native-4.2.3-138",
-                      TOP_BUILD_DIR,
-                      BOOT_DIRECTORY,
-                      os_name)) {
+        if (asprintf(&path2,
+                     "%s/tests/update_playground/%s/%s.native-4.2.3-138",
+                     TOP_BUILD_DIR,
+                     BOOT_DIRECTORY,
+                     os_name) < 0) {
                 abort();
         }
 

--- a/tests/check-files.c
+++ b/tests/check-files.c
@@ -22,6 +22,40 @@
 #include "log.h"
 #include "nica/files.h"
 
+START_TEST(bootman_match_test)
+{
+        const char *source_match = TOP_DIR "/tests/data/match";
+        const char *good_match = TOP_DIR "/tests/data/match1";
+        const char *bad_match_data = TOP_DIR "/tests/data/nomatch1";
+        const char *bad_match_len = TOP_DIR "/tests/data/nomatch2";
+        /* In a clean environment, anyway. */
+        const char *non_exist_path = "PATHTHATWONT@EXIST!";
+
+        /* Known good */
+        fail_if(!cbm_files_match(source_match, good_match), "Known matches failed to match");
+
+        /* Known different data */
+        fail_if(cbm_files_match(source_match, bad_match_data),
+                "Shouldn't match files with different data");
+
+        /* Known different data + length */
+        fail_if(cbm_files_match(source_match, bad_match_len),
+                "Shouldn't match files with different length");
+
+        /* Known missing target, with source present */
+        fail_if(cbm_files_match(source_match, non_exist_path),
+                "Shouldn't match with non existent target");
+
+        /* Known missing source with existing target */
+        fail_if(cbm_files_match(non_exist_path, source_match),
+                "Shouldn't match with non existent source");
+
+        /* Known missing both */
+        fail_if(cbm_files_match(non_exist_path, non_exist_path),
+                "Shouldn't match non existent files");
+}
+END_TEST
+
 START_TEST(bootman_uuid_test)
 {
         if (geteuid() != 0) {
@@ -70,6 +104,7 @@ static Suite *core_suite(void)
 
         s = suite_create("bootman_files");
         tc = tcase_create("bootman_files");
+        tcase_add_test(tc, bootman_match_test);
         tcase_add_test(tc, bootman_uuid_test);
         tcase_add_test(tc, bootman_mount_test);
         tcase_add_test(tc, bootman_find_boot);

--- a/tests/check-files.c
+++ b/tests/check-files.c
@@ -70,7 +70,6 @@ static Suite *core_suite(void)
 
         s = suite_create("bootman_files");
         tc = tcase_create("bootman_files");
-        tcase_add_test(tc, bootman_hash_test);
         tcase_add_test(tc, bootman_uuid_test);
         tcase_add_test(tc, bootman_mount_test);
         tcase_add_test(tc, bootman_find_boot);

--- a/tests/check-files.c
+++ b/tests/check-files.c
@@ -22,21 +22,6 @@
 #include "log.h"
 #include "nica/files.h"
 
-START_TEST(bootman_hash_test)
-{
-        const char *known_sha = "4244d61c4e16e14fd7dc8e4836ca45be98122cb2";
-        const char *path = TOP_DIR "/tests/data/hashfile";
-        char *sha = get_sha1sum(path);
-
-        fail_if(!streq(known_sha, sha), "Computed SHA-1 does not match expectation");
-        free(sha);
-        sha = NULL;
-
-        sha = get_sha1sum("PATHTHATWONT@EXIST!");
-        fail_if(sha, "Got SHA-1 for non-existent path");
-}
-END_TEST
-
 START_TEST(bootman_uuid_test)
 {
         if (geteuid() != 0) {

--- a/tests/data/hashfile
+++ b/tests/data/hashfile
@@ -1,1 +1,0 @@
-This file exists solely for the hashsum checking

--- a/tests/data/match
+++ b/tests/data/match
@@ -1,0 +1,1 @@
+This file is for matching.

--- a/tests/data/match1
+++ b/tests/data/match1
@@ -1,0 +1,1 @@
+This file is for matching.

--- a/tests/data/nomatch1
+++ b/tests/data/nomatch1
@@ -1,0 +1,1 @@
+This file is for matching!

--- a/tests/data/nomatch2
+++ b/tests/data/nomatch2
@@ -1,0 +1,1 @@
+This file is for matching. It differs in length

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -139,21 +139,21 @@ bool set_kernel_default(PlaygroundKernel *kernel)
         autofree(char) *link_source = NULL;
         autofree(char) *link_target = NULL;
 
-        if (!asprintf(&link_source,
-                      "%s.%s.%s-%d",
-                      KERNEL_NAMESPACE,
-                      kernel->ktype,
-                      kernel->version,
-                      kernel->release)) {
+        if (asprintf(&link_source,
+                     "%s.%s.%s-%d",
+                     KERNEL_NAMESPACE,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
                 return false;
         }
 
         /* i.e. default-kvm */
-        if (!asprintf(&link_target,
-                      "%s/%s/default-%s",
-                      PLAYGROUND_ROOT,
-                      KERNEL_DIRECTORY,
-                      kernel->ktype)) {
+        if (asprintf(&link_target,
+                     "%s/%s/default-%s",
+                     PLAYGROUND_ROOT,
+                     KERNEL_DIRECTORY,
+                     kernel->ktype) < 0) {
                 return false;
         }
 
@@ -211,35 +211,35 @@ bool push_kernel_update(PlaygroundKernel *kernel)
         autofree(char) *link_target = NULL;
 
         /* $root/$kerneldir/$prefix.native.4.2.1-137 */
-        if (!asprintf(&kfile,
-                      "%s/%s/%s.%s.%s-%d",
-                      PLAYGROUND_ROOT,
-                      KERNEL_DIRECTORY,
-                      KERNEL_NAMESPACE,
-                      kernel->ktype,
-                      kernel->version,
-                      kernel->release)) {
+        if (asprintf(&kfile,
+                     "%s/%s/%s.%s.%s-%d",
+                     PLAYGROUND_ROOT,
+                     KERNEL_DIRECTORY,
+                     KERNEL_NAMESPACE,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
                 return false;
         }
 
         /* $root/$kerneldir/cmdline-$version-$release.$type */
-        if (!asprintf(&cmdfile,
-                      "%s/%s/cmdline-%s-%d.%s",
-                      PLAYGROUND_ROOT,
-                      KERNEL_DIRECTORY,
-                      kernel->version,
-                      kernel->release,
-                      kernel->ktype)) {
+        if (asprintf(&cmdfile,
+                     "%s/%s/cmdline-%s-%d.%s",
+                     PLAYGROUND_ROOT,
+                     KERNEL_DIRECTORY,
+                     kernel->version,
+                     kernel->release,
+                     kernel->ktype) < 0) {
                 return false;
         }
         /* $root/$kerneldir/config-$version-$release.$type */
-        if (!asprintf(&conffile,
-                      "%s/%s/config-%s-%d.%s",
-                      PLAYGROUND_ROOT,
-                      KERNEL_DIRECTORY,
-                      kernel->version,
-                      kernel->release,
-                      kernel->ktype)) {
+        if (asprintf(&conffile,
+                     "%s/%s/config-%s-%d.%s",
+                     PLAYGROUND_ROOT,
+                     KERNEL_DIRECTORY,
+                     kernel->version,
+                     kernel->release,
+                     kernel->ktype) < 0) {
                 return false;
         }
 
@@ -262,13 +262,13 @@ bool push_kernel_update(PlaygroundKernel *kernel)
                 autofree(char) *t = NULL;
 
                 /* $root/$moduledir/$version-$rel/$p */
-                if (!asprintf(&t,
-                              "%s/%s/%s-%d/%s",
-                              PLAYGROUND_ROOT,
-                              KERNEL_MODULES_DIRECTORY,
-                              kernel->version,
-                              kernel->release,
-                              p)) {
+                if (asprintf(&t,
+                             "%s/%s/%s-%d/%s",
+                             PLAYGROUND_ROOT,
+                             KERNEL_MODULES_DIRECTORY,
+                             kernel->version,
+                             kernel->release,
+                             p) < 0) {
                         return false;
                 }
                 if (!nc_mkdir_p(t, 00755)) {
@@ -282,13 +282,13 @@ bool push_kernel_update(PlaygroundKernel *kernel)
                 autofree(char) *t = NULL;
 
                 /* $root/$moduledir/$version-$rel/$p */
-                if (!asprintf(&t,
-                              "%s/%s/%s-%d/%s",
-                              PLAYGROUND_ROOT,
-                              KERNEL_MODULES_DIRECTORY,
-                              kernel->version,
-                              kernel->release,
-                              p)) {
+                if (asprintf(&t,
+                             "%s/%s/%s-%d/%s",
+                             PLAYGROUND_ROOT,
+                             KERNEL_MODULES_DIRECTORY,
+                             kernel->version,
+                             kernel->release,
+                             p) < 0) {
                         return false;
                 }
                 if (!file_set_text((const char *)t, (char *)kernel->version)) {
@@ -303,7 +303,7 @@ bool push_bootloader_update(int revision)
 {
         autofree(char) *text = NULL;
 
-        if (!asprintf(&text, "faux-bootloader-revision: %d\n", revision)) {
+        if (asprintf(&text, "faux-bootloader-revision: %d\n", revision) < 0) {
                 return false;
         }
 
@@ -421,22 +421,22 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 
         vendor = boot_manager_get_vendor_prefix(manager);
 
-        if (!asprintf(&kernel_blob,
-                      "%s/%s.%s.%s-%d",
-                      BOOT_FULL,
-                      KERNEL_NAMESPACE,
-                      kernel->ktype,
-                      kernel->version,
-                      kernel->release)) {
+        if (asprintf(&kernel_blob,
+                     "%s/%s.%s.%s-%d",
+                     BOOT_FULL,
+                     KERNEL_NAMESPACE,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
                 abort();
         }
-        if (!asprintf(&conf_file,
-                      "%s/loader/entries/%s-%s-%s-%d.conf",
-                      BOOT_FULL,
-                      vendor,
-                      kernel->ktype,
-                      kernel->version,
-                      kernel->release)) {
+        if (asprintf(&conf_file,
+                     "%s/loader/entries/%s-%s-%s-%d.conf",
+                     BOOT_FULL,
+                     vendor,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
                 abort();
         }
 
@@ -462,11 +462,8 @@ bool confirm_kernel_uninstalled(BootManager *manager, PlaygroundKernel *kernel)
 bool create_timeout_conf(void)
 {
         autofree(char) *timeout_conf = NULL;
-        if (!asprintf(&timeout_conf,
-                      "%s/%s/%s",
-                      PLAYGROUND_ROOT,
-                      SYSCONFDIR,
-                      "boot_timeout.conf")) {
+        if (asprintf(&timeout_conf, "%s/%s/%s", PLAYGROUND_ROOT, SYSCONFDIR, "boot_timeout.conf") <
+            0) {
                 return false;
         }
         if (!file_set_text((const char *)timeout_conf, (char *)"5")) {


### PR DESCRIPTION
Removing OpenSSL completely to avoid the upcoming ABI break, using a very simple `mmap` based `memcmp` buffer comparison.

Also fixed several issues in the code to remove potential bugs.