### PR TITLE
bootman: honor PART_UUID env var

### DIFF
--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -87,6 +87,11 @@ char *get_part_uuid(const char *path)
         const char *value = NULL;
         char *ret = NULL;
 
+        ret = getenv("PART_UUID");
+        if (ret != NULL) {
+                return strdup(ret);
+        }
+
         if (stat(path, &st) != 0) {
                 LOG_ERROR("Path does not exist: %s", path);
                 return NULL;


### PR DESCRIPTION
Considering the case where the user wants to generate a tarball archive
with a clr sysroot to later - say - flash it to a device, not necessarily
generating a raw image + filesystem, in that case clr-boot-manager will
not be able to detect the root uuid (since there's not real block device
nor a raw image + loop device).

To overcome the situation the user can now set a PART_UUID env var and
bootman will honor that var.