### PR TITLE
First round of Solus fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ AM_CONDITIONAL([HAVE_SYSTEMD_BOOT], [test x$have_systemdboot = "xyes"])
 AM_CONDITIONAL([HAVE_GUMMIBOOT], [test x$have_gummiboot = "xyes"])
 AM_CONDITIONAL([HAVE_GOOFIBOOT], [test x$have_goofiboot = "xyes"])
 
+# Kernel directory (/usr/lib/kernel)
 AC_ARG_WITH([kernel-dir], AS_HELP_STRING([--with-kernel-dir],
         [the kernel directory to use]), [kerneldir=${withval}],
         [kerneldir="/usr/lib/kernel"])
@@ -90,6 +91,7 @@ AC_SUBST(kerneldir)
 AC_DEFINE_UNQUOTED(KERNEL_DIRECTORY, "$kerneldir",
                    [The location of kernels in this OS configuration])
 
+# Kernel modules directory (/usr/lib/modules)
 AC_ARG_WITH([kernel-modules-dir], AS_HELP_STRING([--with-kernel-modules-dir],
         [the kernel modules directory to use]), [kernelmodulesdir=${withval}],
         [kernelmodulesdir="/usr/lib/modules"])
@@ -98,6 +100,7 @@ AC_SUBST(kernelmodulesdir)
 AC_DEFINE_UNQUOTED(KERNEL_MODULES_DIRECTORY, "$kernelmodulesdir",
                    [The location of kernel modules in this OS configuration])
 
+# Namespace for the kernel (org.clearlinux)
 AC_ARG_WITH([kernel-namespace], AS_HELP_STRING([--with-kernel-namespace],
         [the kernel path namespace to use]), [kernelnamespace=${withval}],
         [kernelnamespace="org.clearlinux"])
@@ -107,6 +110,7 @@ AC_DEFINE_UNQUOTED(KERNEL_NAMESPACE, "$kernelnamespace",
                    [The path namespace for kernels in this OS configuration])
 
 
+# The boot directory (/boot)
 AC_ARG_WITH([boot-dir], AS_HELP_STRING([--with-boot-dir],
         [the path to the normalised ESP mount]), [bootdir=${withval}],
         [bootdir="/boot"])
@@ -114,6 +118,24 @@ AC_ARG_WITH([boot-dir], AS_HELP_STRING([--with-boot-dir],
 AC_SUBST(bootdir)
 AC_DEFINE_UNQUOTED(BOOT_DIRECTORY, "$bootdir",
                    [The normalised path to the boot/ESP mount])
+
+# The vendor name to be used in emitted boot entries
+AC_ARG_WITH([os-name], AS_HELP_STRING([--with-os-name],
+        [the OS name]), [osname=${withval}],
+        [osname="Clear Linux Software for Intel Architecture"])
+
+AC_SUBST(osname)
+AC_DEFINE_UNQUOTED(OS_NAME, "$osname",
+                   [The OS display name])
+
+# The vendor prefix used for files created by clr-boot-manager within bootdir
+AC_ARG_WITH([vendor-prefix], AS_HELP_STRING([--with-vendor-prefix],
+        [the OS name]), [vendorprefix=${withval}],
+        [vendorprefix="Clear-linux"])
+
+AC_SUBST(vendorprefix)
+AC_DEFINE_UNQUOTED(VENDOR_PREFIX, "$vendorprefix",
+                   [The vendor prefix])
 
 # Options
 AC_ARG_WITH([systemdsystemunitdir], AS_HELP_STRING([--with-systemdsystemunitdir=DIR],
@@ -147,6 +169,8 @@ AC_MSG_RESULT([
         kernel-modules-dir:     ${kernelmodulesdir}
         kernel-namespace:       ${kernelnamespace}
         boot-dir:               ${bootdir}
+        os-name:                ${osname}
+        vendor-prefix:          ${vendorprefix}
 
         compatibility scripts:  ${use_compat_scripts}
 ])

--- a/src/bootloaders/bootloader.h
+++ b/src/bootloaders/bootloader.h
@@ -15,7 +15,6 @@
 
 typedef bool (*boot_loader_init)(const BootManager *);
 typedef bool (*boot_loader_install_kernel)(const BootManager *, const Kernel *);
-typedef bool (*boot_loader_is_kernel_installed)(const BootManager *, const Kernel *);
 typedef bool (*boot_loader_remove_kernel)(const BootManager *, const Kernel *);
 typedef bool (*boot_loader_set_default_kernel)(const BootManager *, const Kernel *kernel);
 typedef bool (*boot_loader_needs_update)(const BootManager *);
@@ -29,12 +28,10 @@ typedef void (*boot_loader_destroy)(const BootManager *);
  * Virtual BootLoader provider
  */
 typedef struct BootLoader {
-        const char *name;                          /**<Name of the implementation */
-        boot_loader_init init;                     /**<Init function */
-        boot_loader_install_kernel install_kernel; /**<Install a given kernel */
-        boot_loader_is_kernel_installed
-            is_kernel_installed;                 /**<Determine if the given kernel is installed */
-        boot_loader_remove_kernel remove_kernel; /**<Remove a given kernel */
+        const char *name;                                  /**<Name of the implementation */
+        boot_loader_init init;                             /**<Init function */
+        boot_loader_install_kernel install_kernel;         /**<Install a given kernel */
+        boot_loader_remove_kernel remove_kernel;           /**<Remove a given kernel */
         boot_loader_set_default_kernel set_default_kernel; /**<Set the default kernel */
         boot_loader_needs_update needs_update;             /**<Check if an update is required */
         boot_loader_needs_install needs_install;           /**<Check if an install is required */

--- a/src/bootloaders/goofiboot.c
+++ b/src/bootloaders/goofiboot.c
@@ -27,8 +27,6 @@ static bool goofiboot_init(const BootManager *manager)
 __cbm_export__ const BootLoader goofiboot_bootloader = {.name = "goofiboot",
                                                         .init = goofiboot_init,
                                                         .install_kernel = sd_class_install_kernel,
-                                                        .is_kernel_installed =
-                                                            sd_class_is_kernel_installed,
                                                         .remove_kernel = sd_class_remove_kernel,
                                                         .set_default_kernel =
                                                             sd_class_set_default_kernel,

--- a/src/bootloaders/gummiboot.c
+++ b/src/bootloaders/gummiboot.c
@@ -27,8 +27,6 @@ static bool gummiboot_init(const BootManager *manager)
 __cbm_export__ const BootLoader gummiboot_bootloader = {.name = "gummiboot",
                                                         .init = gummiboot_init,
                                                         .install_kernel = sd_class_install_kernel,
-                                                        .is_kernel_installed =
-                                                            sd_class_is_kernel_installed,
                                                         .remove_kernel = sd_class_remove_kernel,
                                                         .set_default_kernel =
                                                             sd_class_set_default_kernel,

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -97,13 +97,6 @@ static bool syslinux_install_kernel(__cbm_unused__ const BootManager *manager, c
         return true;
 }
 
-/* hack to get all kernels that should be installed in the conf */
-static bool syslinux_is_kernel_installed(__cbm_unused__ const BootManager *manager,
-                                         __cbm_unused__ const Kernel *kernel)
-{
-        return false;
-}
-
 /* No op due since conf file will only have queued kernels anyway */
 static bool syslinux_remove_kernel(__cbm_unused__ const BootManager *manager,
                                    __cbm_unused__ const Kernel *kernel)
@@ -299,8 +292,6 @@ static void syslinux_destroy(__cbm_unused__ const BootManager *manager)
 __cbm_export__ const BootLoader syslinux_bootloader = {.name = "syslinux",
                                                        .init = syslinux_init,
                                                        .install_kernel = syslinux_install_kernel,
-                                                       .is_kernel_installed =
-                                                           syslinux_is_kernel_installed,
                                                        .remove_kernel = syslinux_remove_kernel,
                                                        .set_default_kernel =
                                                            syslinux_set_default_kernel,

--- a/src/bootloaders/systemd-boot.c
+++ b/src/bootloaders/systemd-boot.c
@@ -27,8 +27,6 @@ static bool systemd_boot_init(const BootManager *manager)
 __cbm_export__ const BootLoader systemd_bootloader = {.name = "systemd",
                                                       .init = systemd_boot_init,
                                                       .install_kernel = sd_class_install_kernel,
-                                                      .is_kernel_installed =
-                                                          sd_class_is_kernel_installed,
                                                       .remove_kernel = sd_class_remove_kernel,
                                                       .set_default_kernel =
                                                           sd_class_set_default_kernel,

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -371,7 +371,7 @@ bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kerne
         if (timeout > 0) {
                 /* Set the timeout as configured by the user */
                 if (asprintf(&item_name,
-                             "timeout %d\ndefault %s-%s-%s-%d\n\n",
+                             "timeout %d\ndefault %s-%s-%s-%d\n",
                              timeout,
                              prefix,
                              kernel->ktype,

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -698,14 +698,6 @@ bool sd_class_remove(const BootManager *manager)
         return true;
 }
 
-bool sd_class_is_kernel_installed(const BootManager *manager, const Kernel *kernel)
-{
-        autofree(char) *conf_path = NULL;
-
-        conf_path = get_entry_path_for_kernel((BootManager *)manager, kernel);
-        return nc_file_exists(conf_path);
-}
-
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/bootloaders/systemd-class.h
+++ b/src/bootloaders/systemd-class.h
@@ -26,8 +26,6 @@ typedef struct BootLoaderConfig {
 
 bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel);
 
-bool sd_class_is_kernel_installed(const BootManager *manager, const Kernel *kernel);
-
 bool sd_class_remove_kernel(const BootManager *manager, const Kernel *kernel);
 
 bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kernel);

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -480,18 +480,6 @@ bool boot_manager_needs_update(BootManager *self)
         return self->bootloader->needs_update(self);
 }
 
-bool boot_manager_is_kernel_installed(BootManager *self, const Kernel *kernel)
-{
-        assert(self != NULL);
-
-        /* Ensure the blob is in place */
-        if (!boot_manager_is_kernel_installed_internal(self, kernel)) {
-                return false;
-        }
-        /* Last bits, like config files */
-        return self->bootloader->is_kernel_installed(self, kernel);
-}
-
 bool boot_manager_set_uname(BootManager *self, const char *uname)
 {
         assert(self != NULL);

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -54,8 +54,8 @@ BootManager *boot_manager_new()
         }
 
         /* Potentially consider a configure or os-release check */
-        boot_manager_set_vendor_prefix(r, "Clear-linux");
-        boot_manager_set_os_name(r, "Clear Linux Software for Intel Architecture");
+        boot_manager_set_vendor_prefix(r, VENDOR_PREFIX);
+        boot_manager_set_os_name(r, OS_NAME);
         /* CLI should override these */
         boot_manager_set_can_mount(r, false);
         boot_manager_set_image_mode(r, false);

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -300,8 +300,6 @@ bool boot_manager_needs_install(BootManager *manager);
 
 bool boot_manager_needs_update(BootManager *manager);
 
-bool boot_manager_is_kernel_installed(BootManager *manager, const Kernel *kernel);
-
 /**
  * Get the SystemKernel, if any, for this BootManager.
  *

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -55,6 +55,7 @@ typedef struct Kernel {
         char *module_dir;   /**<Path to the modules directory */
         bool boots;         /**<Is this known to boot? */
         char *kboot_file;   /**<Path to the k_booted_$(uname -r) file */
+        char *initrd_file;  /**<Path to the initrd file */
 } Kernel;
 
 typedef NcArray KernelArray;

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -26,7 +26,7 @@
 struct BootManager {
         char *kernel_dir;             /**<Kernel directory */
         const BootLoader *bootloader; /**<Selected bootloader */
-        char *vendor_prefix;          /**Vendor prefix, i.e. com.blah */
+        char *vendor_prefix;          /**<Vendor prefix, i.e. com.blah */
         char *os_name;                /**<Operating system name */
         char *abs_bootdir;            /**<Real boot dir */
         SystemKernel sys_kernel;      /**<Native kernel info, if any */
@@ -34,6 +34,7 @@ struct BootManager {
         bool can_mount;               /**<Are we allowed to mount? */
         bool image_mode;              /**<Are we in image mode? */
         SystemConfig *sysconfig;      /**<System configuration */
+        char *cmdline;                /**<Additional cmdline to append */
 };
 
 /**

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -38,11 +38,6 @@ struct BootManager {
 };
 
 /**
- * Internal check to see if the kernel blob is installed
- */
-bool boot_manager_is_kernel_installed_internal(const BootManager *manager, const Kernel *kernel);
-
-/**
  * Internal function to install the kernel blob itself
  */
 bool boot_manager_install_kernel_internal(const BootManager *manager, const Kernel *kernel);

--- a/src/bootman/files.c
+++ b/src/bootman/files.c
@@ -344,27 +344,23 @@ end:
 
 bool file_get_text(const char *path, char **out_buf)
 {
-        FILE *fp = NULL;
-        char buffer[CHAR_MAX] = { 0 };
-        bool ret = false;
-        __cbm_unused__ size_t r;
+        autofree(CbmMappedFile) *mapped = CBM_MAPPED_FILE_INIT;
 
         if (!out_buf) {
                 return false;
         }
+        *out_buf = NULL;
 
-        fp = fopen(path, "r");
-        if (!fp) {
+        if (!cbm_mapped_file_open(path, mapped)) {
                 return false;
         }
-        r = fread(buffer, sizeof(buffer), 1, fp);
-        if (!ferror(fp)) {
-                ret = true;
-                *out_buf = strdup(buffer);
-        }
-        fclose(fp);
 
-        return ret;
+        *out_buf = strdup(mapped->buffer);
+
+        if (!*out_buf) {
+                return false;
+        }
+        return true;
 }
 
 bool copy_file(const char *src, const char *target, mode_t mode)

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -523,39 +523,6 @@ Kernel *boot_manager_get_last_booted(BootManager *self, KernelArray *kernels)
 }
 
 /**
- * Internal check to see if the kernel blob is installed
- */
-bool boot_manager_is_kernel_installed_internal(const BootManager *manager, const Kernel *kernel)
-{
-        autofree(char) *path = NULL;
-        autofree(char) *path2 = NULL;
-        autofree(char) *kname_copy = NULL;
-        char *kname_base = NULL;
-        autofree(char) *base_path = NULL;
-
-        assert(manager != NULL);
-        assert(kernel != NULL);
-
-        /* Boot path */
-        base_path = boot_manager_get_boot_dir((BootManager *)manager);
-        OOM_CHECK_RET(base_path, false);
-
-        path = strdup(kernel->path);
-        if (!path) {
-                DECLARE_OOM();
-                abort();
-        }
-        kname_base = basename(path);
-
-        if (asprintf(&path2, "%s/%s", base_path, kname_base) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
-
-        return nc_file_exists(path2);
-}
-
-/**
  * Internal function to install the kernel blob itself
  */
 bool boot_manager_install_kernel_internal(const BootManager *manager, const Kernel *kernel)

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -206,7 +206,19 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
                 buf = NULL;
         }
 
+        /* Use kernel's command line and /etc/kernel/cmdline if present */
+        if (self->cmdline) {
+                char *cm = NULL;
+                if (asprintf(&cm, "%s %s", kern->cmdline, self->cmdline) < 0) {
+                        DECLARE_OOM();
+                        abort();
+                }
+                free(kern->cmdline);
+                kern->cmdline = cm;
+        }
+
         kern->cmdline_file = strdup(cmdline);
+
         if (buf) {
                 free(buf);
         }

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -188,11 +188,6 @@ static bool boot_manager_update_image(BootManager *self)
         /* Go ahead and install the kernels */
         for (uint16_t i = 0; i < kernels->len; i++) {
                 const Kernel *k = nc_array_get(kernels, i);
-                /* Already installed, skip it */
-                if (boot_manager_is_kernel_installed(self, k)) {
-                        LOG_INFO("update_image: Already installed: %s", k->path);
-                        continue;
-                }
                 LOG_DEBUG("update_image: Attempting install of %s", k->path);
                 if (!boot_manager_install_kernel(self, k)) {
                         LOG_FATAL("Cannot install kernel %s", k->path);
@@ -279,15 +274,11 @@ static bool boot_manager_update_native(BootManager *self)
 
         /* This is mostly to allow a repair-situation */
         if (running) {
-                if (!boot_manager_is_kernel_installed(self, running)) {
-                        /* Not necessarily fatal. */
-                        if (!boot_manager_install_kernel(self, running)) {
-                                LOG_ERROR("Failed to repair running kernel");
-                        }
-                        LOG_SUCCESS("update_native: Repaired running kernel %s", running->path);
-                } else {
-                        LOG_INFO("update_native: Running kernel is installed %s", running->path);
+                /* Not necessarily fatal. */
+                if (!boot_manager_install_kernel(self, running)) {
+                        LOG_ERROR("Failed to repair running kernel");
                 }
+                LOG_SUCCESS("update_native: Repaired running kernel %s", running->path);
         }
 
         nc_hashmap_iter_init(mapped_kernels, &map_iter);
@@ -314,41 +305,25 @@ static bool boot_manager_update_native(BootManager *self)
                 }
 
                 /* Ensure this tip kernel is installed */
-                if (!boot_manager_is_kernel_installed(self, tip)) {
-                        if (!boot_manager_install_kernel(self, tip)) {
-                                LOG_FATAL("Failed to install default-%s kernel: %s",
-                                          tip->ktype,
-                                          tip->path);
-                                goto cleanup;
-                        }
-                        LOG_SUCCESS("update_native: Installed tip for %s: %s",
-                                    kernel_type,
-                                    tip->path);
-                } else {
-                        LOG_DEBUG("update_native: Tip for %s already installed: %s",
-                                  kernel_type,
-                                  tip->path);
+                if (!boot_manager_install_kernel(self, tip)) {
+                        LOG_FATAL("Failed to install default-%s kernel: %s", tip->ktype, tip->path);
+                        goto cleanup;
                 }
+                LOG_SUCCESS("update_native: Installed tip for %s: %s", kernel_type, tip->path);
 
                 /* Last known booting kernel, might be null. */
                 last_good = boot_manager_get_last_booted(self, typed_kernels);
 
                 /* Ensure this guy is still installed/repaired */
                 if (last_good) {
-                        if (!boot_manager_is_kernel_installed(self, last_good)) {
-                                if (!boot_manager_install_kernel(self, last_good)) {
-                                        LOG_FATAL("Failed to install last-good kernel: %s",
-                                                  last_good->path);
-                                        goto cleanup;
-                                }
-                                LOG_SUCCESS("update_native: Installed last_good kernel (%s) (%s)",
-                                            kernel_type,
-                                            last_good->path);
-                        } else {
-                                LOG_INFO("update_native: last_good for %s is installed from %s",
-                                         kernel_type,
-                                         last_good->path);
+                        if (!boot_manager_install_kernel(self, last_good)) {
+                                LOG_FATAL("Failed to install last-good kernel: %s",
+                                          last_good->path);
+                                goto cleanup;
                         }
+                        LOG_SUCCESS("update_native: Installed last_good kernel (%s) (%s)",
+                                    kernel_type,
+                                    last_good->path);
                 } else {
                         LOG_DEBUG("update_native: No last_good kernel for type %s", kernel_type);
                 }

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -515,9 +515,8 @@ START_TEST(bootman_timeout_test)
         fail_if(!boot_manager_set_timeout_value(m, 7), "Failed to set timeout value.");
         fail_if(boot_manager_get_timeout_value(m) != 7, "Failed to get correct timeout value.");
         fail_if(!boot_manager_set_timeout_value(m, 0), "Failed to disable timeout value.");
-        fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" SYSCONFDIR
-                                             "/boot_timeout.conf"),
-                "boot_timeout.conf present.");
+        fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/etc/kernel/timeout"),
+                "kernel/timeout present.");
         fail_if(boot_manager_get_timeout_value(m) != -1, "Failed to get default timeout value.");
 }
 END_TEST

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -207,12 +207,25 @@ bool push_kernel_update(PlaygroundKernel *kernel)
         autofree(char) *kfile = NULL;
         autofree(char) *cmdfile = NULL;
         autofree(char) *conffile = NULL;
+        autofree(char) *initrd_file = NULL;
         autofree(char) *link_source = NULL;
         autofree(char) *link_target = NULL;
 
         /* $root/$kerneldir/$prefix.native.4.2.1-137 */
         if (asprintf(&kfile,
                      "%s/%s/%s.%s.%s-%d",
+                     PLAYGROUND_ROOT,
+                     KERNEL_DIRECTORY,
+                     KERNEL_NAMESPACE,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
+                return false;
+        }
+
+        /* $root/$kerneldir/initrd-$prefix.native.4.2.1-137 */
+        if (asprintf(&initrd_file,
+                     "%s/%s/initrd-%s.%s.%s-%d",
                      PLAYGROUND_ROOT,
                      KERNEL_DIRECTORY,
                      KERNEL_NAMESPACE,
@@ -253,6 +266,10 @@ bool push_kernel_update(PlaygroundKernel *kernel)
         }
         /* Write the "config file" */
         if (!file_set_text((const char *)conffile, (char *)kernel->version)) {
+                return false;
+        }
+        /* Write the initrd file */
+        if (!file_set_text((const char *)initrd_file, (char *)kernel->version)) {
                 return false;
         }
 
@@ -416,6 +433,7 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 
         autofree(char) *conf_file = NULL;
         autofree(char) *kernel_blob = NULL;
+        autofree(char) *initrd_file = NULL;
         const char *vendor = NULL;
         int file_count = 0;
 
@@ -423,6 +441,15 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 
         if (asprintf(&kernel_blob,
                      "%s/%s.%s.%s-%d",
+                     BOOT_FULL,
+                     KERNEL_NAMESPACE,
+                     kernel->ktype,
+                     kernel->version,
+                     kernel->release) < 0) {
+                abort();
+        }
+        if (asprintf(&initrd_file,
+                     "%s/initrd-%s.%s.%s-%d",
                      BOOT_FULL,
                      KERNEL_NAMESPACE,
                      kernel->ktype,
@@ -446,12 +473,15 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
         if (nc_file_exists(conf_file)) {
                 ++file_count;
         }
+        if (nc_file_exists(initrd_file)) {
+                ++file_count;
+        }
         return file_count;
 }
 
 bool confirm_kernel_installed(BootManager *manager, PlaygroundKernel *kernel)
 {
-        return kernel_installed_files_count(manager, kernel) == 2;
+        return kernel_installed_files_count(manager, kernel) == 3;
 }
 
 bool confirm_kernel_uninstalled(BootManager *manager, PlaygroundKernel *kernel)

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -492,8 +492,7 @@ bool confirm_kernel_uninstalled(BootManager *manager, PlaygroundKernel *kernel)
 bool create_timeout_conf(void)
 {
         autofree(char) *timeout_conf = NULL;
-        if (asprintf(&timeout_conf, "%s/%s/%s", PLAYGROUND_ROOT, SYSCONFDIR, "boot_timeout.conf") <
-            0) {
+        if (asprintf(&timeout_conf, "%s/%s", PLAYGROUND_ROOT, "etc/kernel/timeout") < 0) {
                 return false;
         }
         if (!file_set_text((const char *)timeout_conf, (char *)"5")) {


### PR DESCRIPTION
 - Allow further control over the branding/naming
 - Add support for initrd files that are provided by the vendor or user. CBM doesn't create these by itself.
 - Add support for `/etc/kernel/cmdline`, to append kernel options
 - Ensure `clr-boot-manager upgrade` always runs, checks available work, and only changes what *needs* changing. This allows `set-timeout` option and the `cmdline` file to be used immediately.
 - Various cleanups, fixes.

I'm putting this set through first, because then I need to get GRUB and LUKS UUID supprt in, as well as replacing our copy of `libnica` with the git submodule.

It should be noted these changes already have benefits for Clear Linux.