### PR TITLE
Write when change

### DIFF
--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -487,9 +487,11 @@ bool boot_manager_install_kernel_internal(const BootManager *manager, const Kern
                 return false;
         }
 
-        if (!copy_file_atomic(kernel->path, kfile_target, 00644)) {
-                LOG_FATAL("Failed to install kernel %s: %s", kfile_target, strerror(errno));
-                return false;
+        if (!cbm_files_match(kernel->path, kfile_target)) {
+                if (!copy_file_atomic(kernel->path, kfile_target, 00644)) {
+                        LOG_FATAL("Failed to install kernel %s: %s", kfile_target, strerror(errno));
+                        return false;
+                }
         }
 
         return true;


### PR DESCRIPTION
This implements issue #31 and unblocks the next release, by only updating target assets, such
as kernel blobs and bootloader text configurations, when they really need updating.