### PR TITLE
Travis GCC5/C11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 
 branches:
   only:
@@ -11,7 +12,7 @@ os:
     - linux
 
 before_script:
-    ./autogen.sh
+    ./autogen.sh CC="gcc-5"
 
 language: c
 
@@ -23,22 +24,21 @@ addons:
             - ubuntu-toolchain-r-test
         packages:
             - check
-            - libblkid-dev
-            - valgrind
-            - lcov
             - clang-3.8
             - clang-format-3.8
+            - gcc-5
+            - libblkid-dev
+            - lcov
             - llvm-3.8
+            - valgrind
+
 
 before_install:
   - gem install coveralls-lcov
-  - wget -nc --no-check-certificate http://downloads.sourceforge.net/ltp/lcov-1.10.tar.gz
-  - tar xzf lcov-1.10.tar.gz
-  - cd lcov-1.10 && make && sudo make install
-  - cd ..
 
 script:
     - lcov --version | grep "1.10"
+    - export CC="gcc-5"
     - ./configure --enable-coverage && make && make check && make distcheck && make check-valgrind
     - clang-format-3.8 -i $(find . -name '*.[ch]') && git diff --exit-code
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -111,7 +111,7 @@ libcbm_la_CFLAGS =		\
 	$(BLKID_CFLAGS)		\
 	$(AM_CFLAGS)
 
-libcbm_LIBADD =			\
+libcbm_la_LIBADD =			\
 	src/libnica/libnica.la
 
 clr_boot_manager_SOURCES =		\

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ AM_CFLAGS = -fstack-protector -Wall -pedantic \
         -Wformat -Wformat-security -Werror=format-security \
         -Wconversion -Wunused-variable -Wunreachable-code \
         -Wall -W -D_FORTIFY_SOURCE=2 \
-        -std=c99 \
+        -std=c11 \
         -DSYSCONFDIR=\"$(sysconfdir)\"
 
 AM_CPPFLAGS = 					 \


### PR DESCRIPTION
 - Switch tree to using GCC 5 (vs GCC 4.8.0 ...)
 - Include updated Nica which has switched to C11
 - Enable C11 by default
 - Fix derp in makefile
 - Underp ordering of travis dependencies