### PR TITLE
Add initial initrd support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -104,6 +104,8 @@ libcbm_la_SOURCES =			\
 	src/lib/os-release.c            \
 	src/lib/log.h			\
 	src/lib/log.c			\
+	src/lib/writer.h                \
+	src/lib/writer.c                \
 	src/lib/util.h
 
 libcbm_la_CFLAGS =		\

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -44,17 +44,19 @@ typedef struct SystemKernel {
  * Represents a kernel in it's complete configuration
  */
 typedef struct Kernel {
-        char *path;         /**<Path to this kernel */
-        char *bpath;        /**<Basename of this kernel path */
-        char *version;      /**<Version of this kernel */
-        int release;        /**<Release number of this kernel */
-        char *ktype;        /**<Type of this kernel */
-        char *cmdline;      /**<Contents of the cmdline file */
-        char *cmdline_file; /**<Path to the cmdline file */
-        char *kconfig_file; /**<Path to the kconfig file */
-        char *module_dir;   /**<Path to the modules directory */
-        bool boots;         /**<Is this known to boot? */
-        char *kboot_file;   /**<Path to the k_booted_$(uname -r) file */
+        char *path;             /**<Path to this kernel */
+        char *bpath;            /**<Basename of this kernel path */
+        char *version;          /**<Version of this kernel */
+        int release;            /**<Release number of this kernel */
+        char *ktype;            /**<Type of this kernel */
+        char *cmdline;          /**<Contents of the cmdline file */
+        char *cmdline_file;     /**<Path to the cmdline file */
+        char *kconfig_file;     /**<Path to the kconfig file */
+        char *initrd_file;      /**<System initrd file */
+        char *user_initrd_file; /**<User's initrd file */
+        char *module_dir;       /**<Path to the modules directory */
+        bool boots;             /**<Is this known to boot? */
+        char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
 } Kernel;
 
 typedef NcArray KernelArray;

--- a/src/lib/writer.c
+++ b/src/lib/writer.c
@@ -1,0 +1,119 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include "writer.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+bool cbm_writer_open(CbmWriter *writer)
+{
+        if (!writer) {
+                return false;
+        }
+
+        if (writer->buffer || writer->memstream) {
+                return false;
+        }
+
+        writer->memstream = open_memstream(&writer->buffer, &writer->buffer_n);
+        if (!writer->memstream) {
+                writer->error = ENOMEM;
+                return false;
+        }
+
+        return true;
+}
+
+void cbm_writer_free(CbmWriter *self)
+{
+        if (!self) {
+                return;
+        }
+        cbm_writer_close(self);
+        free(self->buffer);
+}
+
+void cbm_writer_close(CbmWriter *self)
+{
+        if (!self) {
+                return;
+        }
+        if (!self->memstream) {
+                return;
+        }
+        fclose(self->memstream);
+        self->memstream = NULL;
+}
+
+void cbm_writer_append(CbmWriter *self, const char *s)
+{
+        if (!self || self->error != 0) {
+                return;
+        }
+
+        /* Set EBADF as we tried to use a closed memstream */
+        if (!self->memstream) {
+                self->error = EBADF;
+                return;
+        }
+
+        if (fprintf(self->memstream, "%s", s) < 0) {
+                self->error = errno;
+        }
+}
+
+void cbm_writer_append_printf(CbmWriter *self, const char *fmt, ...)
+{
+        if (!self || self->error != 0) {
+                return;
+        }
+
+        /* Set EBADF as we tried to use a closed memstream */
+        if (!self->memstream) {
+                self->error = EBADF;
+                return;
+        }
+
+        va_list va;
+
+        va_start(va, fmt);
+        if (vfprintf(self->memstream, fmt, va) < 0) {
+                self->error = errno;
+        }
+        va_end(va);
+}
+
+int cbm_writer_error(CbmWriter *self)
+{
+        if (self) {
+                return self->error;
+        }
+        /* Assume enomem with pointer issues */
+        return ENOMEM;
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/writer.h
+++ b/src/lib/writer.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#pragma once
+
+#include "nica/util.h"
+
+#define _GNU_SOURCE
+
+typedef struct CbmWriter {
+        FILE *memstream;
+        char *buffer;
+        size_t buffer_n;
+        int error;
+} CbmWriter;
+
+#define CBM_WRITER_INIT &(CbmWriter){ 0 };
+
+/**
+ * Construct a new CbmWriter
+ */
+bool cbm_writer_open(CbmWriter *writer);
+
+/**
+ * Clean up a previously allocated CbmWriter
+ */
+void cbm_writer_free(CbmWriter *writer);
+
+/**
+ * Close the writer, which will ensure that the buffer is NULL terminated.
+ * No more writes are possible after this close.
+ */
+void cbm_writer_close(CbmWriter *writer);
+
+/**
+ * Append string to the buffer
+ */
+void cbm_writer_append(CbmWriter *writer, const char *s);
+
+/**
+ * Append, printf style, to the buffer
+ */
+void cbm_writer_append_printf(CbmWriter *writer, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
+
+/**
+ * Return an error that may exist in the stream, otherwise 0.
+ * This allows utilising CbmWriter in a failsafe fashion, and checking the
+ * error once only.
+ */
+int cbm_writer_error(CbmWriter *writer);
+
+/* Convenience: Automatically clean up the CbmWriter */
+DEF_AUTOFREE(CbmWriter, cbm_writer_free)
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */


### PR DESCRIPTION
Note this is simply initial initrd support so that the plumbing is in place.

Due to some broken assumptions from the older life of CBM, it prevents "nicely" adding full support for issue #25. A probing method will need to be added to handle GPT vs MBR (PartUUID vs UUID.)

So for now this just adds initrd support to *existing* bootloaders. Should ideally be merged after a new tag for the existing tree so that this can target 2.0

Also note the introduction of simpler string/asprint management to make life easier.