### PR TITLE
Add support for automated building within docker environment.

### DIFF
--- a/continous.sh
+++ b/continous.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# This file is part of clr-boot-manager.
+#
+# Copyright © 2017 Intel Corporation
+#
+# clr-boot-manager is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+
+DIRN="$(basename $(pwd))"
+PROJ_NAME="clr-boot-manager"
+PROJ_CI_NAME="docker-ci-${PROJ_NAME}"
+
+# Check docker is available
+if ! type docker &>/dev/null; then
+    echo "Please ensure docker is installed first"
+    exit 1
+fi
+
+# Check docker is running
+if ! docker version &>/dev/null; then
+    echo "Docker is not running"
+    exit 1
+fi
+
+# Check we're in the right directory
+if [[ "${DIRN}" != "${PROJ_NAME}" ]]; then
+    echo "Please run from the root ${PROJ_NAME} directory"
+    exit 1
+fi
+
+# Check that docker-ci image is installed
+if ! docker inspect "${PROJ_CI_NAME}" &>/dev/null; then
+    echo "${PROJ_CI_NAME} not installed, building docker image.."
+    echo "....Please wait, this may take some time."
+    docker build -t "${PROJ_CI_NAME}" docker/ || exit 1
+fi
+
+# Build the current tree through bind mount within the docker image
+echo "Beginning build of ${PROJ_NAME}..."
+exec docker run -ti -v $(pwd):/source:ro --rm "${PROJ_CI_NAME}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+#
+# This file is part of clr-boot-manager.
+#
+# Copyright © 2017 Intel Corporation
+#
+# clr-boot-manager is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+
+FROM clearlinux:latest
+ADD dockerrun.sh /dockerrun.sh
+RUN swupd update && swupd bundle-add c-basic dev-utils-dev
+
+CMD ["/dockerrun.sh"]

--- a/docker/dockerrun.sh
+++ b/docker/dockerrun.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# This file is part of clr-boot-manager.
+#
+# Copyright © 2017 Intel Corporation
+#
+# clr-boot-manager is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+mkdir -p /build
+cd /build
+
+if [[ ! -d /source ]]; then
+    echo "Missing source tree!" >&2
+    exit 1
+fi
+
+# Copy all the files across to prevent contaminating the bind mount
+cp -Ra /source/. /build
+
+die_fatal()
+{
+    exit 1
+}
+
+die_log_fatal()
+{
+    if [[ -e test-suite.log ]]; then
+        cat test-suite.log
+    else
+        echo "test-suite.log is missing." >&2
+    fi
+    exit 1
+}
+
+./autogen.sh --enable-coverage || die_fatal
+
+# Build error
+make || die_fatal
+
+# Test suite failure, print the log
+make check || die_log_fatal
+
+# tarbal issue, just die
+make distcheck || die_fatal
+
+# Actually checkable on host, but dump log anyway
+make check-valgrind || die_log_fatal
+
+# At this point, we can emit our current coverage to the tty
+make coverage


### PR DESCRIPTION
In order to assist in building up test coverage, we need to do so in a way
that allows to test dangerous changes locally. Emulating an environment that
has no /sys or /dev is absurdly difficult.

Instead, we add a method to enable building (reproducibly) within a Docker
image based on Clear Linux. The build will take a full snapshot of the
current tree from a *read-only* bind mount into the target tree. At this
point it will attempt all parts of the normal Travis build steps, and will
ultimately emit the contents of the build log should failures be encountered.

Additionally we have the added benefit of working with a modern toolchain,
as opposed to the very old offerings on Travis.

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>