### PR TITLE
Remove the compatibility scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,18 +23,7 @@ EXTRA_DIST = ${top_srcdir}/README.md \
 	     ${top_srcdir}/tests/data/etc/kernel/cmdline.d/30_third.conf \
 	     ${top_srcdir}/sgcheck.suppressions \
 	     ${top_srcdir}/data/clr-boot-manager-booted.service \
-	     ${top_srcdir}/compat/kernel_updater.sh \
-	     ${top_srcdir}/compat/systemdboot_updater.sh \
-	     ${top_srcdir}/compat/gummiboot_updaters.sh \
 	     ${top_srcdir}/man/clr-boot-manager.1
-
-
-if COMPAT_SCRIPTS
-bin_SCRIPTS = \
-	compat/kernel_updater.sh \
-	compat/systemdboot_updater.sh \
-	compat/gummiboot_updaters.sh
-endif
 
 NULL =
 CLEANFILES =

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,5 +1,0 @@
-compat
-------
-
-The scripts in this directory are simply to provide upgrade support during
-format bumps, by way of proxy.

--- a/compat/gummiboot_updaters.sh
+++ b/compat/gummiboot_updaters.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-clr-boot-manager update $*

--- a/compat/kernel_updater.sh
+++ b/compat/kernel_updater.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-clr-boot-manager update $*

--- a/compat/systemdboot_updater.sh
+++ b/compat/systemdboot_updater.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-clr-boot-manager update $*

--- a/configure.ac
+++ b/configure.ac
@@ -32,18 +32,6 @@ if test "x$enable_coverage" = "xyes" ; then
 fi
 AM_CONDITIONAL([COVERAGE], [test "$have_coverage" = "yes"])
 
-# Enable compat scripts? Enabled by default
-AC_ARG_ENABLE(compat-scripts, AS_HELP_STRING([--enable-compat-scripts], [enable compat scripts]))
-use_compat_scripts=yes
-if test x$enable_compat_scripts = "xno"; then
-        use_compat_scripts="no"
-else
-        use_compat_scripts="yes"
-fi
-
-AM_CONDITIONAL([COMPAT_SCRIPTS], [test "$use_compat_scripts" = "yes"])
-
-
 AC_ARG_WITH([bootloader], AS_HELP_STRING([--with-bootloader=BOOTLOADER],
         [the bootloader to use]), [bootloader=${withval}],
         [bootloader="auto"])
@@ -172,6 +160,4 @@ AC_MSG_RESULT([
         kernel-conf-dir:        ${kernelconfdir}
         boot-dir:               ${bootdir}
         vendor-prefix:          ${vendorprefix}
-
-        compatibility scripts:  ${use_compat_scripts}
 ])


### PR DESCRIPTION
These scripts were originally needed when transitioning to clr-boot-manager
within Clear Linux. However, they will no longer be invoked by swupd-client
due to clearlinux/swupd-client#179 so we will now remove them "at source".

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>

P.S. This also means this change can only be released in 2.0 and not before.