### PR TITLE
bootloader/syslinux: Fix nasty segfault

### DIFF
--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -136,8 +136,8 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
 
         for (uint16_t i = 0; i < kernel_queue->len; i++) {
                 const Kernel *k = nc_array_get(kernel_queue, i);
-                autofree(char) *kname_base = NULL;
-                char *kname_copy = NULL;
+                char *kname_base = NULL;
+                autofree(char) *kname_copy = NULL;
                 autofree(char) *initrd_copy = NULL;
                 char *initrd_base = NULL;
 


### PR DESCRIPTION
This change corrects a bug found in the coverage testing, whereby the wrong
item was freed (The modified pointer, not the original copy pointer.)

Signed-off-by: Ikey Doherty <michael.i.doherty@intel.com>