### PR TITLE
asprintf based coverage helping

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,7 +103,8 @@ libcbm_la_SOURCES =			\
 	src/lib/system_stub.c           \
 	src/lib/writer.h                \
 	src/lib/writer.c                \
-	src/lib/util.h
+	src/lib/util.h			\
+	src/lib/util.c
 
 libcbm_la_CFLAGS =		\
 	-D_BOOTMAN_INTERNAL_	\

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -41,7 +41,6 @@ static bool syslinux_init(const BootManager *manager)
 {
         autofree(char) *ldlinux = NULL;
         const char *prefix = NULL;
-        int ret = 0;
 
         if (kernel_queue) {
                 kernel_array_free(kernel_queue);
@@ -62,27 +61,17 @@ static bool syslinux_init(const BootManager *manager)
                 free(extlinux_cmd);
                 extlinux_cmd = NULL;
         }
-        if (asprintf(&ldlinux, "%s/ldlinux.sys", base_path) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+
+        ldlinux = string_printf("%s/ldlinux.sys", base_path);
 
         prefix = boot_manager_get_prefix((BootManager *)manager);
 
         if (nc_file_exists(ldlinux)) {
-                ret = asprintf(&extlinux_cmd,
-                               "%s/usr/bin/extlinux -U %s &> /dev/null",
-                               prefix,
-                               base_path);
+                extlinux_cmd =
+                    string_printf("%s/usr/bin/extlinux -U %s &> /dev/null", prefix, base_path);
         } else {
-                ret = asprintf(&extlinux_cmd,
-                               "%s/usr/bin/extlinux -i %s &> /dev/null",
-                               prefix,
-                               base_path);
-        }
-        if (ret < 0) {
-                DECLARE_OOM();
-                abort();
+                extlinux_cmd =
+                    string_printf("%s/usr/bin/extlinux -i %s &> /dev/null", prefix, base_path);
         }
 
         return true;
@@ -120,10 +109,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 return false;
         }
 
-        if (asprintf(&config_path, "%s/syslinux.cfg", base_path) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+        config_path = string_printf("%s/syslinux.cfg", base_path);
 
         if (!cbm_writer_open(writer)) {
                 DECLARE_OOM();
@@ -240,10 +226,8 @@ static bool syslinux_install(const BootManager *manager)
                 return false;
         }
 
-        if (asprintf(&syslinux_path, "%s/usr/share/syslinux/gptmbr.bin", prefix) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+        syslinux_path = string_printf("%s/usr/share/syslinux/gptmbr.bin", prefix);
+
         syslinux_mbr = open(syslinux_path, O_RDONLY);
         if (syslinux_mbr < 0) {
                 close(mbr);

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -84,15 +84,8 @@ bool sd_class_init(const BootManager *manager, BootLoaderConfig *config)
         prefix = boot_manager_get_prefix((BootManager *)manager);
 
         /* EFI paths */
-        if (asprintf(&efi_blob_source,
-                     "%s/%s/%s",
-                     prefix,
-                     sd_config->efi_dir,
-                     sd_config->efi_blob) < 0) {
-                sd_class_destroy(manager);
-                DECLARE_OOM();
-                return false;
-        }
+        efi_blob_source =
+            string_printf("%s/%s/%s", prefix, sd_config->efi_dir, sd_config->efi_blob);
         sd_class_config.efi_blob_source = efi_blob_source;
 
         efi_blob_dest = nc_build_case_correct_path(sd_class_config.base_path,
@@ -144,15 +137,11 @@ static char *get_entry_path_for_kernel(BootManager *manager, const Kernel *kerne
 
         prefix = boot_manager_get_vendor_prefix(manager);
 
-        if (asprintf(&item_name,
-                     "%s-%s-%s-%d.conf",
-                     prefix,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+        item_name = string_printf("%s-%s-%s-%d.conf",
+                                  prefix,
+                                  kernel->ktype,
+                                  kernel->version,
+                                  kernel->release);
 
         return nc_build_case_correct_path(sd_class_config.base_path,
                                           "loader",
@@ -344,26 +333,18 @@ bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kerne
 
         if (timeout > 0) {
                 /* Set the timeout as configured by the user */
-                if (asprintf(&item_name,
-                             "timeout %d\ndefault %s-%s-%s-%d\n",
-                             timeout,
-                             prefix,
-                             kernel->ktype,
-                             kernel->version,
-                             kernel->release) < 0) {
-                        DECLARE_OOM();
-                        return false;
-                }
+                item_name = string_printf("timeout %d\ndefault %s-%s-%s-%d\n",
+                                          timeout,
+                                          prefix,
+                                          kernel->ktype,
+                                          kernel->version,
+                                          kernel->release);
         } else {
-                if (asprintf(&item_name,
-                             "default %s-%s-%s-%d\n",
-                             prefix,
-                             kernel->ktype,
-                             kernel->version,
-                             kernel->release) < 0) {
-                        DECLARE_OOM();
-                        return false;
-                }
+                item_name = string_printf("default %s-%s-%s-%d\n",
+                                          prefix,
+                                          kernel->ktype,
+                                          kernel->version,
+                                          kernel->release);
         }
 
 write_config:

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -106,10 +106,7 @@ bool boot_manager_set_prefix(BootManager *self, char *prefix)
                 self->kernel_dir = NULL;
         }
 
-        if (asprintf(&kernel_dir, "%s/%s", config->prefix, KERNEL_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+        kernel_dir = string_printf("%s/%s", config->prefix, KERNEL_DIRECTORY);
 
         if (self->kernel_dir) {
                 free(self->kernel_dir);
@@ -259,10 +256,7 @@ char *boot_manager_get_boot_dir(BootManager *self)
                 return strdup(self->abs_bootdir);
         }
 
-        if (asprintf(&ret, "%s%s", self->sysconfig->prefix, BOOT_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                abort();
-        }
+        ret = string_printf("%s%s", self->sysconfig->prefix, BOOT_DIRECTORY);
         return ret;
 }
 

--- a/src/bootman/timeout.c
+++ b/src/bootman/timeout.c
@@ -31,20 +31,14 @@ bool boot_manager_set_timeout_value(BootManager *self, int timeout)
                 return false;
         }
 
-        if (asprintf(&dir, "%s%s", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
+        dir = string_printf("%s%s", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY);
 
         if (!nc_mkdir_p(dir, 00755)) {
                 LOG_ERROR("Failed to create directory %s: %s", dir, strerror(errno));
                 return false;
         }
 
-        if (asprintf(&path, "%s%s/timeout", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
+        path = string_printf("%s%s/timeout", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY);
 
         if (timeout <= 0) {
                 /* Nothing to be done here. */
@@ -81,10 +75,7 @@ int boot_manager_get_timeout_value(BootManager *self)
                 return false;
         }
 
-        if (asprintf(&path, "%s%s/timeout", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                return -1;
-        }
+        path = string_printf("%s%s/timeout", self->sysconfig->prefix, KERNEL_CONF_DIRECTORY);
 
         /* Default timeout being -1, i.e. don't use one */
         if (!nc_file_exists(path)) {

--- a/src/cli/ops/report_booted.c
+++ b/src/cli/ops/report_booted.c
@@ -56,14 +56,8 @@ bool cbm_command_report_booted(__cbm_unused__ int argc, __cbm_unused__ char **ar
         }
 
         /* /var/lib/kernel/k_booted_4.4.0-120.lts - new */
-        if (asprintf(&boot_rep_path,
-                     "/var/lib/kernel/k_booted_%s-%d.%s",
-                     sys.version,
-                     sys.release,
-                     sys.ktype) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
+        boot_rep_path =
+            string_printf("/var/lib/kernel/k_booted_%s-%d.%s", sys.version, sys.release, sys.ktype);
 
         /* Report ourselves to new path */
         if (!file_set_text(boot_rep_path, "clr-boot-manager file\n")) {

--- a/src/lib/cmdline.c
+++ b/src/lib/cmdline.c
@@ -136,16 +136,8 @@ char *cbm_parse_cmdline_files(const char *root)
         size_t arg_start = 0;
 
         /* global cmdline */
-        if (asprintf(&cmdline, "%s/%s/cmdline", root, KERNEL_CONF_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
-
-        /* glob match */
-        if (asprintf(&globfile, "%s/%s/cmdline.d/*.conf", root, KERNEL_CONF_DIRECTORY) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
+        cmdline = string_printf("%s/%s/cmdline", root, KERNEL_CONF_DIRECTORY);
+        globfile = string_printf("%s/%s/cmdline.d/*.conf", root, KERNEL_CONF_DIRECTORY);
 
         memstr = open_memstream(&buf, &sz);
         if (!memstr) {

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -93,12 +93,8 @@ char *get_boot_device()
         autofree(char) *glob_path = NULL;
         autofree(char) *dev_path = NULL;
 
-        if (asprintf(&glob_path,
-                     "%s/firmware/efi/efivars/LoaderDevicePartUUID*",
-                     cbm_system_get_sysfs_path()) < 0) {
-                DECLARE_OOM();
-                return NULL;
-        }
+        glob_path = string_printf("%s/firmware/efi/efivars/LoaderDevicePartUUID*",
+                                  cbm_system_get_sysfs_path());
 
         glob(glob_path, GLOB_DOOFFS, NULL, &glo);
 
@@ -138,20 +134,15 @@ char *get_boot_device()
         }
         read_buf[j] = '\0';
 
-        if (asprintf(&p, "%s/disk/by-partuuid/%s", cbm_system_get_devfs_path(), uuid) < 0) {
-                DECLARE_OOM();
-                return NULL;
-        }
+        p = string_printf("%s/disk/by-partuuid/%s", cbm_system_get_devfs_path(), uuid);
 
         if (nc_file_exists(p)) {
                 return strdup(p);
         }
 next:
 
-        if (asprintf(&dev_path, "%s/disk/by-partlabel/ESP", cbm_system_get_devfs_path()) < 0) {
-                DECLARE_OOM();
-                return NULL;
-        }
+        dev_path = string_printf("%s/disk/by-partlabel/ESP", cbm_system_get_devfs_path());
+
         if (nc_file_exists(dev_path)) {
                 return strdup(dev_path);
         }
@@ -189,10 +180,7 @@ char *get_parent_disk(char *path)
                 return NULL;
         }
 
-        if (asprintf(&node, "%s/block/%u:%u", devfs, major(devt), minor(devt)) < 0) {
-                DECLARE_OOM();
-                return NULL;
-        }
+        node = string_printf("%s/block/%u:%u", devfs, major(devt), minor(devt));
         return realpath(node, NULL);
 }
 
@@ -247,10 +235,7 @@ char *get_legacy_boot_device(char *path)
                                 LOG_ERROR("Not a valid GPT disk");
                                 goto clean;
                         }
-                        if (asprintf(&pt_path, "%s/disk/by-partuuid/%s", devfs, part_id) < 0) {
-                                DECLARE_OOM();
-                                goto clean;
-                        }
+                        pt_path = string_printf("%s/disk/by-partuuid/%s", devfs, part_id);
                         ret = realpath(pt_path, NULL);
                         break;
                 }
@@ -369,9 +354,7 @@ bool copy_file_atomic(const char *src, const char *target, mode_t mode)
         autofree(char) *new_name = NULL;
         struct stat st = { 0 };
 
-        if (asprintf(&new_name, "%s.TmpWrite", target) < 0) {
-                return false;
-        }
+        new_name = string_printf("%s.TmpWrite", target);
 
         if (!copy_file(src, new_name, mode)) {
                 (void)unlink(new_name);
@@ -455,10 +438,8 @@ char *cbm_get_mountpoint_for_device(const char *device)
 bool cbm_system_has_uefi()
 {
         autofree(char) *p = NULL;
-        if (asprintf(&p, "%s/firmware/efi", cbm_system_get_sysfs_path()) < 0) {
-                DECLARE_OOM();
-                return false;
-        }
+
+        p = string_printf("%s/firmware/efi", cbm_system_get_sysfs_path());
         return nc_file_exists(p);
 }
 

--- a/src/lib/os-release.c
+++ b/src/lib/os-release.c
@@ -190,10 +190,7 @@ CbmOsRelease *cbm_os_release_new_for_root(const char *root)
         for (size_t i = 0; i < ARRAY_SIZE(files); i++) {
                 autofree(char) *p = NULL;
 
-                if (asprintf(&p, "%s/%s", root, files[i]) < 0) {
-                        DECLARE_OOM();
-                        return NULL;
-                }
+                p = string_printf("%s/%s", root, files[i]);
 
                 if (!nc_file_exists(p)) {
                         continue;

--- a/src/lib/probe.c
+++ b/src/lib/probe.c
@@ -68,10 +68,7 @@ static char *cbm_get_luks_uuid(const char *part)
         const char *sys = cbm_system_get_sysfs_path();
 
         /* i.e. /sys/block/dm-1/slaves/dm-0/slaves/sdb1/dev */
-        if (asprintf(&npath, "%s/block/%s/slaves/*/slaves/*/dev", sys, part) < 0) {
-                DECLARE_OOM();
-                return NULL;
-        }
+        npath = string_printf("%s/block/%s/slaves/*/slaves/*/dev", sys, part);
 
         glob(npath, GLOB_DOOFFS, NULL, &glo);
 

--- a/src/lib/system_stub.c
+++ b/src/lib/system_stub.c
@@ -24,15 +24,14 @@
  */
 static char *cbm_devnode_to_devpath(dev_t dev)
 {
+        autofree(char) *c = NULL;
+
         if (major(dev) == 0) {
                 LOG_ERROR("Invalid block device: %u:%u", major(dev), minor(dev));
                 return NULL;
         }
 
-        autofree(char) *c = NULL;
-        if (asprintf(&c, "/dev/block/%u:%u", major(dev), minor(dev)) < 0) {
-                return NULL;
-        }
+        c = string_printf("/dev/block/%u:%u", major(dev), minor(dev));
         return realpath(c, NULL);
 }
 

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -1,0 +1,50 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016-2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+
+#include <ctype.h>
+
+#include "util.h"
+
+char *rstrip(char *a, size_t len, ssize_t *newlen)
+{
+        char *e = a + len - 1;
+        if (len < 1) {
+                return a;
+        }
+
+        for (;;) {
+                if (!isspace(*e) || e <= a) {
+                        break;
+                }
+                --e;
+        }
+        if (newlen) {
+                *newlen = e - a + 1;
+        }
+
+        *(e + 1) = '\0';
+        return a;
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -12,6 +12,7 @@
 #define _GNU_SOURCE
 
 #include <ctype.h>
+#include <stdarg.h>
 
 #include "util.h"
 
@@ -34,6 +35,19 @@ char *rstrip(char *a, size_t len, ssize_t *newlen)
 
         *(e + 1) = '\0';
         return a;
+}
+
+char *string_printf(const char *fmt, ...)
+{
+        char *ret = NULL;
+        va_list va;
+        va_start(va, fmt);
+        if (vasprintf(&ret, fmt, va) < 0) {
+                DECLARE_OOM();
+                abort();
+        }
+        va_end(va);
+        return ret;
 }
 
 /*

--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -15,7 +15,6 @@
 
 #include "nica/util.h"
 
-#include <ctype.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -56,26 +55,7 @@
  * Strip the right side of a string of it's whitespace
  * This must be allocated memory
  */
-static inline char *rstrip(char *a, size_t len, ssize_t *newlen)
-{
-        char *e = a + len - 1;
-        if (len < 1) {
-                return a;
-        }
-
-        for (;;) {
-                if (!isspace(*e) || e <= a) {
-                        break;
-                }
-                --e;
-        }
-        if (newlen) {
-                *newlen = e - a + 1;
-        }
-
-        *(e + 1) = '\0';
-        return a;
-}
+char *rstrip(char *a, size_t len, ssize_t *newlen);
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/lib/util.h
+++ b/src/lib/util.h
@@ -57,6 +57,14 @@
  */
 char *rstrip(char *a, size_t len, ssize_t *newlen);
 
+/**
+ * Similar to asprintf, but will assert allocation of the string.
+ * Failure to do so will result in an abort, as there is nothing
+ * further than clr-boot-manager can do when it has run out of
+ * memory.
+ */
+char *string_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -85,9 +85,7 @@ START_TEST(bootman_legacy_get_boot_device)
         boot_device = get_legacy_boot_device(PLAYGROUND_ROOT);
         fail_if(!boot_device, "Failed to determine legacy boot device");
 
-        if (asprintf(&exp, "%s/dev/disk/by-partuuid/Test-PartUUID", PLAYGROUND_ROOT) < 0) {
-                abort();
-        }
+        exp = string_printf("%s/dev/disk/by-partuuid/Test-PartUUID", PLAYGROUND_ROOT);
         fail_if(!streq(exp, boot_device), "Boot device does not match expected result");
 }
 END_TEST

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -59,11 +59,8 @@ START_TEST(bootman_uefi_get_boot_device)
         boot_device = get_boot_device();
         fail_if(!boot_device, "Failed to determine UEFI boot device");
 
-        if (asprintf(&exp,
-                     "%s/dev/disk/by-partuuid/e90f44b5-bb8a-41af-b680-b0bf5b0f2a65",
-                     PLAYGROUND_ROOT) < 0) {
-                abort();
-        }
+        exp = string_printf("%s/dev/disk/by-partuuid/e90f44b5-bb8a-41af-b680-b0bf5b0f2a65",
+                            PLAYGROUND_ROOT);
         fail_if(!streq(exp, boot_device), "Boot device does not match expected result");
 }
 END_TEST

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -152,23 +152,15 @@ bool set_kernel_default(PlaygroundKernel *kernel)
         autofree(char) *link_source = NULL;
         autofree(char) *link_target = NULL;
 
-        if (asprintf(&link_source,
-                     "%s.%s.%s-%d",
-                     KERNEL_NAMESPACE,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                return false;
-        }
+        link_source = string_printf("%s.%s.%s-%d",
+                                    KERNEL_NAMESPACE,
+                                    kernel->ktype,
+                                    kernel->version,
+                                    kernel->release);
 
         /* i.e. default-kvm */
-        if (asprintf(&link_target,
-                     "%s/%s/default-%s",
-                     PLAYGROUND_ROOT,
-                     KERNEL_DIRECTORY,
-                     kernel->ktype) < 0) {
-                return false;
-        }
+        link_target =
+            string_printf("%s/%s/default-%s", PLAYGROUND_ROOT, KERNEL_DIRECTORY, kernel->ktype);
 
         /* Purge old link */
         if (nc_file_exists(link_target) && unlink(link_target) < 0) {
@@ -192,14 +184,11 @@ bool set_kernel_booted(PlaygroundKernel *kernel, bool did_boot)
         }
         autofree(char) *p = NULL;
 
-        if (asprintf(&p,
-                     "%s/var/lib/kernel/k_booted_%s-%d.%s",
-                     PLAYGROUND_ROOT,
-                     kernel->version,
-                     kernel->release,
-                     kernel->ktype) < 0) {
-                return false;
-        }
+        p = string_printf("%s/var/lib/kernel/k_booted_%s-%d.%s",
+                          PLAYGROUND_ROOT,
+                          kernel->version,
+                          kernel->release,
+                          kernel->ktype);
 
         if (!did_boot) {
                 if (nc_file_exists(p) && unlink(p) < 0) {
@@ -225,49 +214,38 @@ bool push_kernel_update(PlaygroundKernel *kernel)
         autofree(char) *initrd_file = NULL;
 
         /* $root/$kerneldir/$prefix.native.4.2.1-137 */
-        if (asprintf(&kfile,
-                     "%s/%s/%s.%s.%s-%d",
-                     PLAYGROUND_ROOT,
-                     KERNEL_DIRECTORY,
-                     KERNEL_NAMESPACE,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                return false;
-        }
+        kfile = string_printf("%s/%s/%s.%s.%s-%d",
+                              PLAYGROUND_ROOT,
+                              KERNEL_DIRECTORY,
+                              KERNEL_NAMESPACE,
+                              kernel->ktype,
+                              kernel->version,
+                              kernel->release);
 
         /* $root/$kerneldir/initrd-$prefix.native.4.2.1-137 */
-        if (asprintf(&initrd_file,
-                     "%s/%s/initrd-%s.%s.%s-%d",
-                     PLAYGROUND_ROOT,
-                     KERNEL_DIRECTORY,
-                     KERNEL_NAMESPACE,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                return false;
-        }
+        initrd_file = string_printf("%s/%s/initrd-%s.%s.%s-%d",
+                                    PLAYGROUND_ROOT,
+                                    KERNEL_DIRECTORY,
+                                    KERNEL_NAMESPACE,
+                                    kernel->ktype,
+                                    kernel->version,
+                                    kernel->release);
 
         /* $root/$kerneldir/cmdline-$version-$release.$type */
-        if (asprintf(&cmdfile,
-                     "%s/%s/cmdline-%s-%d.%s",
-                     PLAYGROUND_ROOT,
-                     KERNEL_DIRECTORY,
-                     kernel->version,
-                     kernel->release,
-                     kernel->ktype) < 0) {
-                return false;
-        }
+        cmdfile = string_printf("%s/%s/cmdline-%s-%d.%s",
+                                PLAYGROUND_ROOT,
+                                KERNEL_DIRECTORY,
+                                kernel->version,
+                                kernel->release,
+                                kernel->ktype);
+
         /* $root/$kerneldir/config-$version-$release.$type */
-        if (asprintf(&conffile,
-                     "%s/%s/config-%s-%d.%s",
-                     PLAYGROUND_ROOT,
-                     KERNEL_DIRECTORY,
-                     kernel->version,
-                     kernel->release,
-                     kernel->ktype) < 0) {
-                return false;
-        }
+        conffile = string_printf("%s/%s/config-%s-%d.%s",
+                                 PLAYGROUND_ROOT,
+                                 KERNEL_DIRECTORY,
+                                 kernel->version,
+                                 kernel->release,
+                                 kernel->ktype);
 
         /* Write the "kernel blob" */
         if (!file_set_text((const char *)kfile, (char *)kernel->version)) {
@@ -292,15 +270,12 @@ bool push_kernel_update(PlaygroundKernel *kernel)
                 autofree(char) *t = NULL;
 
                 /* $root/$moduledir/$version-$rel/$p */
-                if (asprintf(&t,
-                             "%s/%s/%s-%d/%s",
-                             PLAYGROUND_ROOT,
-                             KERNEL_MODULES_DIRECTORY,
-                             kernel->version,
-                             kernel->release,
-                             p) < 0) {
-                        return false;
-                }
+                t = string_printf("%s/%s/%s-%d/%s",
+                                  PLAYGROUND_ROOT,
+                                  KERNEL_MODULES_DIRECTORY,
+                                  kernel->version,
+                                  kernel->release,
+                                  p);
                 if (!nc_mkdir_p(t, 00755)) {
                         fprintf(stderr, "Failed to mkdir: %s %s\n", p, strerror(errno));
                         return false;
@@ -312,15 +287,12 @@ bool push_kernel_update(PlaygroundKernel *kernel)
                 autofree(char) *t = NULL;
 
                 /* $root/$moduledir/$version-$rel/$p */
-                if (asprintf(&t,
-                             "%s/%s/%s-%d/%s",
-                             PLAYGROUND_ROOT,
-                             KERNEL_MODULES_DIRECTORY,
-                             kernel->version,
-                             kernel->release,
-                             p) < 0) {
-                        return false;
-                }
+                t = string_printf("%s/%s/%s-%d/%s",
+                                  PLAYGROUND_ROOT,
+                                  KERNEL_MODULES_DIRECTORY,
+                                  kernel->version,
+                                  kernel->release,
+                                  p);
                 if (!file_set_text((const char *)t, (char *)kernel->version)) {
                         fprintf(stderr, "Failed to touch: %s %s\n", t, strerror(errno));
                         return false;
@@ -333,9 +305,7 @@ bool push_bootloader_update(int revision)
 {
         autofree(char) *text = NULL;
 
-        if (asprintf(&text, "faux-bootloader-revision: %d\n", revision) < 0) {
-                return false;
-        }
+        text = string_printf("faux-bootloader-revision: %d\n", revision);
 
         if (!nc_file_exists(BOOT_COPY_DIR)) {
                 if (!nc_mkdir_p(BOOT_COPY_DIR, 00755)) {
@@ -467,33 +437,26 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 
         vendor = boot_manager_get_vendor_prefix(manager);
 
-        if (asprintf(&kernel_blob,
-                     "%s/%s.%s.%s-%d",
-                     BOOT_FULL,
-                     KERNEL_NAMESPACE,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                abort();
-        }
-        if (asprintf(&initrd_file,
-                     "%s/initrd-%s.%s.%s-%d",
-                     BOOT_FULL,
-                     KERNEL_NAMESPACE,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                abort();
-        }
-        if (asprintf(&conf_file,
-                     "%s/loader/entries/%s-%s-%s-%d.conf",
-                     BOOT_FULL,
-                     vendor,
-                     kernel->ktype,
-                     kernel->version,
-                     kernel->release) < 0) {
-                abort();
-        }
+        kernel_blob = string_printf("%s/%s.%s.%s-%d",
+                                    BOOT_FULL,
+                                    KERNEL_NAMESPACE,
+                                    kernel->ktype,
+                                    kernel->version,
+                                    kernel->release);
+
+        initrd_file = string_printf("%s/initrd-%s.%s.%s-%d",
+                                    BOOT_FULL,
+                                    KERNEL_NAMESPACE,
+                                    kernel->ktype,
+                                    kernel->version,
+                                    kernel->release);
+
+        conf_file = string_printf("%s/loader/entries/%s-%s-%s-%d.conf",
+                                  BOOT_FULL,
+                                  vendor,
+                                  kernel->ktype,
+                                  kernel->version,
+                                  kernel->release);
 
         if (nc_file_exists(kernel_blob)) {
                 ++file_count;
@@ -521,9 +484,8 @@ bool confirm_kernel_uninstalled(BootManager *manager, PlaygroundKernel *kernel)
 bool create_timeout_conf(void)
 {
         autofree(char) *timeout_conf = NULL;
-        if (asprintf(&timeout_conf, "%s/%s/timeout", PLAYGROUND_ROOT, KERNEL_CONF_DIRECTORY) < 0) {
-                return false;
-        }
+
+        timeout_conf = string_printf("%s/%s/timeout", PLAYGROUND_ROOT, KERNEL_CONF_DIRECTORY);
         if (!file_set_text((const char *)timeout_conf, (char *)"5")) {
                 fprintf(stderr, "Failed to touch: %s %s\n", timeout_conf, strerror(errno));
                 return false;
@@ -539,38 +501,27 @@ void set_test_system_uefi(void)
         autofree(char) *ddir = NULL;
 
         /* Create fake UEFI variables */
-        if (asprintf(&root, "%s/firmware/efi/efivars", cbm_system_get_sysfs_path()) < 0) {
-                goto mem_fail;
-        }
+        root = string_printf("%s/firmware/efi/efivars", cbm_system_get_sysfs_path());
         nc_mkdir_p(root, 00755);
 
         /* Create fake LoaderDevicePartUUID */
-        if (asprintf(&lfile, "%s/LoaderDevicePartUUID-dummyRoot", root) < 0) {
-                goto mem_fail;
-        }
+        lfile = string_printf("%s/LoaderDevicePartUUID-dummyRoot", root);
         if (!file_set_text(lfile, "E90F44B5-BB8A-41AF-B680-B0BF5B0F2A65")) {
-                goto mem_fail;
+                DECLARE_OOM();
+                abort();
         }
 
         /* Create /dev/disk/by-partuuid portions */
-        if (asprintf(&ddir, "%s/disk/by-partuuid", cbm_system_get_devfs_path()) < 0) {
-                goto mem_fail;
-        }
+        ddir = string_printf("%s/disk/by-partuuid", cbm_system_get_devfs_path());
 
-        if (asprintf(&dfile, "%s/e90f44b5-bb8a-41af-b680-b0bf5b0f2a65", ddir) < 0) {
-                goto mem_fail;
-        }
+        dfile = string_printf("%s/e90f44b5-bb8a-41af-b680-b0bf5b0f2a65", ddir);
 
         /* commit them to disk */
         nc_mkdir_p(ddir, 00755);
         if (!file_set_text(dfile, "clr-boot-manager UEFI testing")) {
-                goto mem_fail;
+                DECLARE_OOM();
+                abort();
         }
-        return;
-
-mem_fail:
-        DECLARE_OOM();
-        abort();
 }
 
 void set_test_system_legacy(void)
@@ -583,23 +534,18 @@ void set_test_system_legacy(void)
         const char *devfs_path = cbm_system_get_devfs_path();
 
         /* dev tree */
-        if (asprintf(&ddir, "%s/block", devfs_path) < 0) {
-                goto mem_fail;
-        }
+        ddir = string_printf("%s/block", devfs_path);
 
         /* dev/block link */
-        if (asprintf(&dlink, "%s/block/%u:%u", devfs_path, 8, 8) < 0) {
-                goto mem_fail;
-        }
+        dlink = string_printf("%s/block/%u:%u", devfs_path, 8, 8);
 
         /* "real" dev file for realpath()ing */
-        if (asprintf(&dfile, "%s/leRootDevice", devfs_path) < 0) {
-                goto mem_fail;
-        }
+        dfile = string_printf("%s/leRootDevice", devfs_path);
 
         nc_mkdir_p(ddir, 00755);
         if (!file_set_text(dfile, "le-root-device")) {
-                goto mem_fail;
+                DECLARE_OOM();
+                abort();
         }
 
         if (symlink("../leRootDevice", dlink) != 0) {
@@ -608,21 +554,14 @@ void set_test_system_legacy(void)
         }
 
         /* Create /dev/disk/by-partuuid portions */
-        if (asprintf(&diskdir, "%s/disk/by-partuuid", cbm_system_get_devfs_path()) < 0) {
-                goto mem_fail;
-        }
-        if (asprintf(&diskfile, "%s/%s", diskdir, "Test-PartUUID") < 0) {
-                goto mem_fail;
-        }
+        diskdir = string_printf("%s/disk/by-partuuid", cbm_system_get_devfs_path());
+        diskfile = string_printf("%s/%s", diskdir, "Test-PartUUID");
+
         nc_mkdir_p(diskdir, 00755);
         if (!file_set_text(diskfile, "clr-boot-manager Legacy testing")) {
-                goto mem_fail;
+                DECLARE_OOM();
+                abort();
         }
-        return;
-
-mem_fail:
-        DECLARE_OOM();
-        abort();
 }
 
 /*

--- a/tests/system-harness.h
+++ b/tests/system-harness.h
@@ -43,11 +43,7 @@ static inline char *test_get_mountpoint_for_device(__cbm_unused__ const char *de
 
 static inline char *test_devnode_to_devpath(__cbm_unused__ dev_t d)
 {
-        char *a = NULL;
-        if (asprintf(&a, "%s/dev/testRoot", TOP_BUILD_DIR "/tests/update_playground") < 0) {
-                abort();
-        }
-        return a;
+        return string_printf("%s/dev/testRoot", TOP_BUILD_DIR "/tests/update_playground");
 }
 
 static inline const char *test_get_sysfs_path(void)


### PR DESCRIPTION
This change should raise the coverage up almost 2%, by adding a new `util.c`, with a `string_printf` helper to remove all the `if !string; abort` flow.

I also un-inlined `rstrip` as it made no sense to be inlined. Most importantly, this change makes the code easier to follow.