### PR TITLE
Cleanup & capabilities

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ AM_CFLAGS = -fstack-protector -Wall -pedantic \
         -Wformat -Wformat-security -Werror=format-security \
         -Wconversion -Wunused-variable -Wunreachable-code \
         -Wall -W -D_FORTIFY_SOURCE=2 \
+        -Wno-missing-field-initializers \
         -std=c11 \
         -DSYSCONFDIR=\"$(sysconfdir)\"
 

--- a/src/bootloaders/bootloader.h
+++ b/src/bootloaders/bootloader.h
@@ -29,6 +29,15 @@ typedef bool (*boot_loader_install)(const BootManager *);
 typedef bool (*boot_loader_update)(const BootManager *);
 typedef bool (*boot_loader_remove)(const BootManager *);
 typedef void (*boot_loader_destroy)(const BootManager *);
+typedef int (*boot_loader_caps)(const BootManager *);
+
+typedef enum {
+        BOOTLOADER_CAP_MIN = 1 << 0,
+        BOOTLOADER_CAP_UEFI = 1 << 1,   /**<Bootloader supports UEFI */
+        BOOTLOADER_CAP_GPT = 1 << 2,    /**<Bootloader supports GPT boot partition */
+        BOOTLOADER_CAP_LEGACY = 1 << 3, /**<Bootloader supports legacy boot */
+        BOOTLOADER_CAP_MAX = 1 << 4
+} BootLoaderCapability;
 
 /**
  * Virtual BootLoader provider
@@ -43,8 +52,9 @@ typedef struct BootLoader {
         boot_loader_needs_install needs_install;           /**<Check if an install is required */
         boot_loader_install install;                       /**<Install this bootloader */
         boot_loader_update update;                         /**<Update this bootloader */
-        boot_loader_remove remove;   /**<Remove this bootloader from the disk */
-        boot_loader_destroy destroy; /**<Perform necessary cleanups */
+        boot_loader_remove remove;         /**<Remove this bootloader from the disk */
+        boot_loader_destroy destroy;       /**<Perform necessary cleanups */
+        boot_loader_caps get_capabilities; /**<Check capabilities */
 } BootLoader;
 
 #define __cbm_export__ __attribute__((visibility("default")))

--- a/src/bootloaders/goofiboot.c
+++ b/src/bootloaders/goofiboot.c
@@ -34,7 +34,9 @@ __cbm_export__ const BootLoader goofiboot_bootloader = {.name = "goofiboot",
                                                         .install = sd_class_install,
                                                         .update = sd_class_update,
                                                         .remove = sd_class_remove,
-                                                        .destroy = sd_class_destroy };
+                                                        .destroy = sd_class_destroy,
+                                                        .get_capabilities =
+                                                            sd_class_get_capabilities };
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/bootloaders/gummiboot.c
+++ b/src/bootloaders/gummiboot.c
@@ -34,7 +34,9 @@ __cbm_export__ const BootLoader gummiboot_bootloader = {.name = "gummiboot",
                                                         .install = sd_class_install,
                                                         .update = sd_class_update,
                                                         .remove = sd_class_remove,
-                                                        .destroy = sd_class_destroy };
+                                                        .destroy = sd_class_destroy,
+                                                        .get_capabilities =
+                                                            sd_class_get_capabilities };
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -278,6 +278,11 @@ static void syslinux_destroy(__cbm_unused__ const BootManager *manager)
         }
 }
 
+static int syslinux_get_capabilities(__cbm_unused__ const BootManager *manager)
+{
+        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_LEGACY;
+}
+
 __cbm_export__ const BootLoader syslinux_bootloader = {.name = "syslinux",
                                                        .init = syslinux_init,
                                                        .install_kernel = syslinux_install_kernel,
@@ -289,7 +294,9 @@ __cbm_export__ const BootLoader syslinux_bootloader = {.name = "syslinux",
                                                        .install = syslinux_install,
                                                        .update = syslinux_update,
                                                        .remove = syslinux_remove,
-                                                       .destroy = syslinux_destroy };
+                                                       .destroy = syslinux_destroy,
+                                                       .get_capabilities =
+                                                           syslinux_get_capabilities };
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/bootloaders/systemd-boot.c
+++ b/src/bootloaders/systemd-boot.c
@@ -34,7 +34,9 @@ __cbm_export__ const BootLoader systemd_bootloader = {.name = "systemd",
                                                       .install = sd_class_install,
                                                       .update = sd_class_update,
                                                       .remove = sd_class_remove,
-                                                      .destroy = sd_class_destroy };
+                                                      .destroy = sd_class_destroy,
+                                                      .get_capabilities =
+                                                          sd_class_get_capabilities };
 
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -523,6 +523,12 @@ bool sd_class_remove(const BootManager *manager)
         return true;
 }
 
+int sd_class_get_capabilities(__cbm_unused__ const BootManager *manager)
+{
+        /* Very trivial bootloader, we support UEFI/GPT only */
+        return BOOTLOADER_CAP_GPT | BOOTLOADER_CAP_UEFI;
+}
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -280,8 +280,6 @@ bool sd_class_remove_kernel(const BootManager *manager, const Kernel *kernel)
         }
 
         autofree(char) *conf_path = NULL;
-        autofree(char) *kname_copy = NULL;
-        autofree(char) *kfile_target = NULL;
 
         conf_path = get_entry_path_for_kernel((BootManager *)manager, kernel);
         OOM_CHECK_RET(conf_path, false);

--- a/src/bootloaders/systemd-class.h
+++ b/src/bootloaders/systemd-class.h
@@ -49,6 +49,8 @@ bool sd_class_init(const BootManager *manager, BootLoaderConfig *config);
 
 void sd_class_destroy(const BootManager *manager);
 
+int sd_class_get_capabilities(const BootManager *manager);
+
 /*
  * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
  *

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -332,7 +332,7 @@ bool boot_manager_set_boot_dir(BootManager *self, const char *bootdir)
         return true;
 }
 
-bool boot_manager_modify_bootloader(BootManager *self, BootLoaderOperation op)
+bool boot_manager_modify_bootloader(BootManager *self, int flags)
 {
         assert(self != NULL);
 
@@ -343,19 +343,20 @@ bool boot_manager_modify_bootloader(BootManager *self, BootLoaderOperation op)
         if (!cbm_is_sysconfig_sane(self->sysconfig)) {
                 return false;
         }
+        bool nocheck = (flags & BOOTLOADER_OPERATION_NO_CHECK) == BOOTLOADER_OPERATION_NO_CHECK;
 
-        if (op & BOOTLOADER_OPERATION_INSTALL) {
-                if (op & BOOTLOADER_OPERATION_NO_CHECK) {
+        if ((flags & BOOTLOADER_OPERATION_INSTALL) == BOOTLOADER_OPERATION_INSTALL) {
+                if (nocheck) {
                         return self->bootloader->install(self);
                 }
                 if (self->bootloader->needs_install(self)) {
                         return self->bootloader->install(self);
                 }
                 return true;
-        } else if (op & BOOTLOADER_OPERATION_REMOVE) {
+        } else if ((flags & BOOTLOADER_OPERATION_REMOVE) == BOOTLOADER_OPERATION_REMOVE) {
                 return self->bootloader->remove(self);
-        } else if (op & BOOTLOADER_OPERATION_UPDATE) {
-                if (op & BOOTLOADER_OPERATION_NO_CHECK) {
+        } else if ((flags & BOOTLOADER_OPERATION_UPDATE) == BOOTLOADER_OPERATION_UPDATE) {
+                if (nocheck) {
                         return self->bootloader->update(self);
                 }
                 if (self->bootloader->needs_update(self)) {

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -223,7 +223,7 @@ const CbmDeviceProbe *boot_manager_get_root_device(BootManager *manager);
 /**
  * Attempt installation of the bootloader
  */
-bool boot_manager_modify_bootloader(BootManager *manager, BootLoaderOperation op);
+bool boot_manager_modify_bootloader(BootManager *manager, int ops);
 
 /**
  * Determine if the BootManager is operating in image mode, i.e.

--- a/src/bootman/kernel.c
+++ b/src/bootman/kernel.c
@@ -52,7 +52,6 @@ Kernel *boot_manager_inspect_kernel(BootManager *self, char *path)
         autofree(char) *cmdline = NULL;
         autofree(char) *module_dir = NULL;
         autofree(char) *kconfig_file = NULL;
-        autofree(char) *default_file = NULL;
         autofree(char) *initrd_file = NULL;
         autofree(char) *user_initrd_file = NULL;
         ssize_t r = 0;

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -375,7 +375,7 @@ static bool boot_manager_update_native(BootManager *self)
         /* Might return NULL */
         if (!running) {
                 /* Attempt to get it based on the current uname anyway */
-                if (system_kernel && system_kernel->ktype) {
+                if (system_kernel && system_kernel->ktype[0] != '\0') {
                         new_default =
                             boot_manager_get_default_for_type(self, kernels, system_kernel->ktype);
                 }

--- a/src/lib/cmdline.c
+++ b/src/lib/cmdline.c
@@ -42,7 +42,6 @@ static bool cbm_parse_cmdline_file_internal(const char *path, FILE *out)
 
         while ((r = getline(&buf, &sn, f)) > 0) {
                 ssize_t cur = 0;
-                autofree(char) *value = NULL;
 
                 /* Strip newlines */
                 if (r >= 1 && buf[r - 1] == '\n') {

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -35,8 +35,6 @@
 #include "system_stub.h"
 #include "util.h"
 
-DEF_AUTOFREE(DIR, closedir)
-
 /**
  * Legacy boot bit, i.e. partition flag on a GPT disk
  */

--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -31,14 +31,14 @@ void cbm_log_init(FILE *log)
 {
         const char *env_level = NULL;
         log_file = log;
-        int nlog_level = CBM_LOG_ERROR;
+        unsigned int nlog_level = CBM_LOG_ERROR;
 
         env_level = getenv("CBM_DEBUG");
         if (env_level) {
                 /* =1 becomes 0 */
-                nlog_level = atoi(env_level) - 1;
+                nlog_level = ((unsigned int)atoi(env_level)) - 1;
         }
-        if (nlog_level < CBM_LOG_DEBUG || nlog_level >= CBM_LOG_MAX) {
+        if (nlog_level >= CBM_LOG_MAX) {
                 nlog_level = CBM_LOG_FATAL;
         }
         min_log_level = nlog_level;
@@ -54,7 +54,7 @@ __attribute__((constructor)) static void cbm_log_first_init(void)
 
 static inline const char *cbm_log_level_str(CbmLogLevel l)
 {
-        if (l >= 0 && l <= CBM_LOG_FATAL) {
+        if (l <= CBM_LOG_FATAL) {
                 return log_str_table[l];
         }
         return "unknown";


### PR DESCRIPTION
So I started this branch with the intent of enabling secure boot but got distracted by some
obvious things that gcc was missing (unused autofrees) - so after the caps were added I
set about cleaning those up.

Anyway, I need the capability stuff in for the secure boot bits too, as I'll want to ask the bootloader if its UEFI, then prefix the paths with `EFI/` and do the migration bits. I suspect the coverage is gonna drop a half percent here, apologies. I'll make it back up in the next change hopefully, though I need migration & inclusion of sboot bits..