### PR TITLE
Be nicer to ESP (+ secure boot)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,15 @@ AC_SUBST(vendorprefix)
 AC_DEFINE_UNQUOTED(VENDOR_PREFIX, "$vendorprefix",
                    [The vendor prefix])
 
+# The shim stage 2 name to use (i.e. "loader" or "grub")
+AC_ARG_WITH([shim-stage2-prefix], AS_HELP_STRING([--shim-stage2-prefix],
+        [the prefix that SHIM expects]), [shimprefix=${withval}],
+        [shimprefix="loader"])
+
+AC_SUBST(shimprefix)
+AC_DEFINE_UNQUOTED(SHIM_STAGE2_PREFIX, "$shimprefix",
+                   [shim stage2 prefix for the bootloader])
+
 # The kernel configuration directory
 AC_ARG_WITH([kernel-conf-dir], AS_HELP_STRING([--with-kernel-conf-dir],
         [the kernel configuration directory]), [kernelconfdir=${withval}],
@@ -160,4 +169,5 @@ AC_MSG_RESULT([
         kernel-conf-dir:        ${kernelconfdir}
         boot-dir:               ${bootdir}
         vendor-prefix:          ${vendorprefix}
+        shim stage2 prefix:     ${shimprefix}
 ])

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -126,11 +126,11 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
 
                 /* Mark it default */
                 if (default_kernel && streq(k->source.path, default_kernel->source.path)) {
-                        cbm_writer_append_printf(writer, "DEFAULT %s\n", k->target.path);
+                        cbm_writer_append_printf(writer, "DEFAULT %s\n", k->target.legacy_path);
                 }
 
-                cbm_writer_append_printf(writer, "LABEL %s\n", k->target.path);
-                cbm_writer_append_printf(writer, "  KERNEL %s\n", k->target.path);
+                cbm_writer_append_printf(writer, "LABEL %s\n", k->target.legacy_path);
+                cbm_writer_append_printf(writer, "  KERNEL %s\n", k->target.legacy_path);
                 /* Add the initrd if we found one */
                 if (k->target.initrd_path) {
                         cbm_writer_append_printf(writer, "  INITRD %s\n", k->target.initrd_path);

--- a/src/bootloaders/syslinux.c
+++ b/src/bootloaders/syslinux.c
@@ -105,7 +105,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
 
         root_dev = boot_manager_get_root_device((BootManager *)manager);
         if (!root_dev) {
-                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->path);
+                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->source.path);
                 return false;
         }
 
@@ -128,7 +128,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 autofree(char) *initrd_copy = NULL;
                 char *initrd_base = NULL;
 
-                kname_copy = strdup(k->path);
+                kname_copy = strdup(k->source.path);
                 if (!kname_copy) {
                         DECLARE_OOM();
                         abort();
@@ -136,8 +136,8 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 kname_base = basename(kname_copy);
 
                 /* Get the basename of the initrd blob, if it exists */
-                if (kernel && kernel->initrd_file) {
-                        initrd_copy = strdup(kernel->initrd_file);
+                if (kernel && kernel->source.initrd_file) {
+                        initrd_copy = strdup(kernel->source.initrd_file);
                         if (!initrd_copy) {
                                 DECLARE_OOM();
                                 abort();
@@ -146,7 +146,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 }
 
                 /* Mark it default */
-                if (kernel && streq(k->path, kernel->path)) {
+                if (kernel && streq(k->source.path, kernel->source.path)) {
                         cbm_writer_append_printf(writer, "DEFAULT %s\n", kname_base);
                 }
 
@@ -172,7 +172,7 @@ static bool syslinux_set_default_kernel(const BootManager *manager, const Kernel
                 }
 
                 /* Write out the cmdline */
-                cbm_writer_append_printf(writer, "%s\n", k->cmdline);
+                cbm_writer_append_printf(writer, "%s\n", k->meta.cmdline);
         }
 
         cbm_writer_close(writer);

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -18,6 +18,7 @@
 
 #include "bootloader.h"
 #include "bootman.h"
+#include "config.h"
 #include "files.h"
 #include "log.h"
 #include "nica/files.h"
@@ -208,10 +209,16 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
 
         /* Standard title + linux lines */
         cbm_writer_append_printf(writer, "title %s\n", os_name);
-        cbm_writer_append_printf(writer, "linux /%s\n", kernel->target.path);
+        cbm_writer_append_printf(writer,
+                                 "linux /EFI/%s/%s\n",
+                                 KERNEL_NAMESPACE,
+                                 kernel->target.path);
         /* Optional initrd */
         if (kernel->target.initrd_path) {
-                cbm_writer_append_printf(writer, "initrd /%s\n", kernel->target.initrd_path);
+                cbm_writer_append_printf(writer,
+                                         "initrd /EFI/%s/%s\n",
+                                         KERNEL_NAMESPACE,
+                                         kernel->target.initrd_path);
         }
         /* Add the root= section */
         if (root_dev->part_uuid) {

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -180,10 +180,6 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         }
         autofree(char) *conf_path = NULL;
         const CbmDeviceProbe *root_dev = NULL;
-        autofree(char) *kname_copy = NULL;
-        char *kname_base = NULL;
-        autofree(char) *initrd_copy = NULL;
-        char *initrd_base = NULL;
         const char *os_name = NULL;
         autofree(char) *old_conf = NULL;
         autofree(CbmWriter) *writer = CBM_WRITER_INIT;
@@ -208,31 +204,14 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
                 return false;
         }
 
-        kname_copy = strdup(kernel->source.path);
-        if (!kname_copy) {
-                DECLARE_OOM();
-                abort();
-        }
-        kname_base = basename(kname_copy);
-
-        /* Get the basename of the initrd blob, if it exists */
-        if (kernel->source.initrd_file) {
-                initrd_copy = strdup(kernel->source.initrd_file);
-                if (!initrd_copy) {
-                        DECLARE_OOM();
-                        abort();
-                }
-                initrd_base = basename(initrd_copy);
-        }
-
         os_name = boot_manager_get_os_name((BootManager *)manager);
 
         /* Standard title + linux lines */
         cbm_writer_append_printf(writer, "title %s\n", os_name);
-        cbm_writer_append_printf(writer, "linux /%s\n", kname_base);
+        cbm_writer_append_printf(writer, "linux /%s\n", kernel->target.path);
         /* Optional initrd */
-        if (initrd_base) {
-                cbm_writer_append_printf(writer, "initrd /%s\n", initrd_base);
+        if (kernel->target.initrd_path) {
+                cbm_writer_append_printf(writer, "initrd /%s\n", kernel->target.initrd_path);
         }
         /* Add the root= section */
         if (root_dev->part_uuid) {

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -139,9 +139,9 @@ static char *get_entry_path_for_kernel(BootManager *manager, const Kernel *kerne
 
         item_name = string_printf("%s-%s-%s-%d.conf",
                                   prefix,
-                                  kernel->ktype,
-                                  kernel->version,
-                                  kernel->release);
+                                  kernel->meta.ktype,
+                                  kernel->meta.version,
+                                  kernel->meta.release);
 
         return nc_build_case_correct_path(sd_class_config.base_path,
                                           "loader",
@@ -204,11 +204,11 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         /* Build the options for the entry */
         root_dev = boot_manager_get_root_device((BootManager *)manager);
         if (!root_dev) {
-                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->path);
+                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->source.path);
                 return false;
         }
 
-        kname_copy = strdup(kernel->path);
+        kname_copy = strdup(kernel->source.path);
         if (!kname_copy) {
                 DECLARE_OOM();
                 abort();
@@ -216,8 +216,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         kname_base = basename(kname_copy);
 
         /* Get the basename of the initrd blob, if it exists */
-        if (kernel->initrd_file) {
-                initrd_copy = strdup(kernel->initrd_file);
+        if (kernel->source.initrd_file) {
+                initrd_copy = strdup(kernel->source.initrd_file);
                 if (!initrd_copy) {
                         DECLARE_OOM();
                         abort();
@@ -246,7 +246,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         }
 
         /* Finish it off with the command line options */
-        cbm_writer_append_printf(writer, "%s\n", kernel->cmdline);
+        cbm_writer_append_printf(writer, "%s\n", kernel->meta.cmdline);
         cbm_writer_close(writer);
 
         if (cbm_writer_error(writer) != 0) {
@@ -263,7 +263,7 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
 
         if (!file_set_text(conf_path, writer->buffer)) {
                 LOG_FATAL("Failed to create loader entry for: %s [%s]",
-                          kernel->path,
+                          kernel->source.path,
                           strerror(errno));
                 return false;
         }
@@ -334,15 +334,15 @@ bool sd_class_set_default_kernel(const BootManager *manager, const Kernel *kerne
                 item_name = string_printf("timeout %d\ndefault %s-%s-%s-%d\n",
                                           timeout,
                                           prefix,
-                                          kernel->ktype,
-                                          kernel->version,
-                                          kernel->release);
+                                          kernel->meta.ktype,
+                                          kernel->meta.version,
+                                          kernel->meta.release);
         } else {
                 item_name = string_printf("default %s-%s-%s-%d\n",
                                           prefix,
-                                          kernel->ktype,
-                                          kernel->version,
-                                          kernel->release);
+                                          kernel->meta.ktype,
+                                          kernel->meta.version,
+                                          kernel->meta.release);
         }
 
 write_config:

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -69,6 +69,7 @@ typedef struct Kernel {
         /* Target (basename) paths */
         struct {
                 char *path;        /**<Basename path of the kernel for the target */
+                char *legacy_path; /**<Old path prior to namespacing (basename) */
                 char *initrd_path; /**<Basename path of initrd for the target */
         } target;
 } Kernel;

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -45,19 +45,26 @@ typedef struct SystemKernel {
  * Represents a kernel in it's complete configuration
  */
 typedef struct Kernel {
-        char *path;             /**<Path to this kernel */
-        char *bpath;            /**<Basename of this kernel path */
-        char *version;          /**<Version of this kernel */
-        int release;            /**<Release number of this kernel */
-        char *ktype;            /**<Type of this kernel */
-        char *cmdline;          /**<Contents of the cmdline file */
-        char *cmdline_file;     /**<Path to the cmdline file */
-        char *kconfig_file;     /**<Path to the kconfig file */
-        char *initrd_file;      /**<System initrd file */
-        char *user_initrd_file; /**<User's initrd file */
-        char *module_dir;       /**<Path to the modules directory */
-        bool boots;             /**<Is this known to boot? */
-        char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
+        /* Metadata */
+        struct {
+                char *bpath;   /**<Basename of this kernel path */
+                char *version; /**<Version of this kernel */
+                int release;   /**<Release number of this kernel */
+                char *ktype;   /**<Type of this kernel */
+                char *cmdline; /**<Contents of the cmdline file */
+                bool boots;    /**<Is this known to boot? */
+        } meta;
+
+        /* Source paths */
+        struct {
+                char *path;             /**<Path to this kernel */
+                char *cmdline_file;     /**<Path to the cmdline file */
+                char *kconfig_file;     /**<Path to the kconfig file */
+                char *initrd_file;      /**<System initrd file */
+                char *user_initrd_file; /**<User's initrd file */
+                char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
+                char *module_dir;       /**<Path to the modules directory */
+        } source;
 } Kernel;
 
 typedef NcArray KernelArray;

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -65,6 +65,12 @@ typedef struct Kernel {
                 char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
                 char *module_dir;       /**<Path to the modules directory */
         } source;
+
+        /* Target (basename) paths */
+        struct {
+                char *path;        /**<Basename path of the kernel for the target */
+                char *initrd_path; /**<Basename path of initrd for the target */
+        } target;
 } Kernel;
 
 typedef NcArray KernelArray;

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -116,6 +116,15 @@ bool boot_manager_update(BootManager *self)
         LOG_SUCCESS("%s successfully mounted at %s", root_base, boot_dir);
         did_mount = true;
 
+        /* Reinit bootloader for non-image mode with newly mounted boot partition
+         * as it may have paths that already exist, and we must adjust for case
+         * sensitivity (ignorant) issues
+         */
+        if (!boot_manager_set_boot_dir(self, boot_dir)) {
+                LOG_FATAL("Cannot initialise with newly mounted ESP");
+                return false;
+        }
+
 perform:
         /* Do a native update */
         ret = boot_manager_update_native(self);

--- a/tests/check-core.c
+++ b/tests/check-core.c
@@ -142,7 +142,7 @@ int kernel_compare(const void *a, const void *b)
         const Kernel *ka = *(const Kernel **)a;
         const Kernel *kb = *(const Kernel **)b;
 
-        if (ka->release < kb->release) {
+        if (ka->meta.release < kb->meta.release) {
                 return -1;
         }
         return 1;
@@ -153,7 +153,7 @@ int kernel_compare_reverse(const void *a, const void *b)
         const Kernel *ka = *(const Kernel **)a;
         const Kernel *kb = *(const Kernel **)b;
 
-        if (ka->release > kb->release) {
+        if (ka->meta.release > kb->meta.release) {
                 return -1;
         }
         return 1;
@@ -180,24 +180,24 @@ START_TEST(bootman_list_kernels_test)
         /* Normal sort test */
         nc_array_qsort(list, kernel_compare);
         kernel = nc_array_get(list, 0);
-        fail_if(kernel->release != 121, "Invalid first element");
+        fail_if(kernel->meta.release != 121, "Invalid first element");
         kernel = nc_array_get(list, 1);
-        fail_if(kernel->release != 124, "Invalid second element");
+        fail_if(kernel->meta.release != 124, "Invalid second element");
         kernel = nc_array_get(list, 2);
-        fail_if(kernel->release != 137, "Invalid third element");
+        fail_if(kernel->meta.release != 137, "Invalid third element");
         kernel = nc_array_get(list, 3);
-        fail_if(kernel->release != 138, "Invalid fourth element");
+        fail_if(kernel->meta.release != 138, "Invalid fourth element");
 
         /* Reverse sort test */
         nc_array_qsort(list, kernel_compare_reverse);
         kernel = nc_array_get(list, 0);
-        fail_if(kernel->release != 138, "Invalid first reversed element");
+        fail_if(kernel->meta.release != 138, "Invalid first reversed element");
         kernel = nc_array_get(list, 1);
-        fail_if(kernel->release != 137, "Invalid second reversed element");
+        fail_if(kernel->meta.release != 137, "Invalid second reversed element");
         kernel = nc_array_get(list, 2);
-        fail_if(kernel->release != 124, "Invalid third reversed element");
+        fail_if(kernel->meta.release != 124, "Invalid third reversed element");
         kernel = nc_array_get(list, 3);
-        fail_if(kernel->release != 121, "Invalid fourth reversed element");
+        fail_if(kernel->meta.release != 121, "Invalid fourth reversed element");
 }
 END_TEST
 
@@ -233,17 +233,17 @@ START_TEST(bootman_map_kernels_test)
         /* default-kvm = "org.clearlinux.kvm.4.2.3-124" */
         default_kernel = boot_manager_get_default_for_type(m, list, "kvm");
         fail_if(!default_kernel, "Failed to find default kvm kernel");
-        fail_if(default_kernel->release != 124, "Mismatched kvm default release");
-        fail_if(!streq(default_kernel->version, "4.2.3"), "Mismatched kvm default version");
-        fail_if(!streq(default_kernel->ktype, "kvm"), "Mismatched kvm default type");
+        fail_if(default_kernel->meta.release != 124, "Mismatched kvm default release");
+        fail_if(!streq(default_kernel->meta.version, "4.2.3"), "Mismatched kvm default version");
+        fail_if(!streq(default_kernel->meta.ktype, "kvm"), "Mismatched kvm default type");
         default_kernel = NULL;
 
         /* default-native = "org.clearlinux.native.4.2.3-138" */
         default_kernel = boot_manager_get_default_for_type(m, list, "native");
         fail_if(!default_kernel, "Failed to find default native kernel");
-        fail_if(default_kernel->release != 138, "Mismatched native default release");
-        fail_if(!streq(default_kernel->version, "4.2.3"), "Mismatched native default version");
-        fail_if(!streq(default_kernel->ktype, "native"), "Mismatched native default type");
+        fail_if(default_kernel->meta.release != 138, "Mismatched native default release");
+        fail_if(!streq(default_kernel->meta.version, "4.2.3"), "Mismatched native default version");
+        fail_if(!streq(default_kernel->meta.ktype, "native"), "Mismatched native default type");
 }
 END_TEST
 

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -179,7 +179,7 @@ START_TEST(bootman_legacy_update_from_unknown)
         /* Check running kernel */
         running_kernel = boot_manager_get_running_kernel(m, post_kernels);
         fail_if(!running_kernel, "Failed to find kernel post reboot");
-        fail_if(!streq(running_kernel->version, "4.2.1"), "Running kernel is invalid");
+        fail_if(!streq(running_kernel->meta.version, "4.2.1"), "Running kernel is invalid");
 }
 END_TEST
 

--- a/tests/check-legacy.c
+++ b/tests/check-legacy.c
@@ -58,10 +58,10 @@ static inline const char *legacy_partition_get_uuid(__cbm_unused__ blkid_partiti
         return DEFAULT_PART_UUID;
 }
 
-static PlaygroundKernel legacy_kernels[] = { { "4.2.1", "kvm", 121, false },
-                                             { "4.2.3", "kvm", 124, true },
-                                             { "4.2.1", "native", 137, false },
-                                             { "4.2.3", "native", 138, true } };
+static PlaygroundKernel legacy_kernels[] = { { "4.2.1", "kvm", 121, false, true },
+                                             { "4.2.3", "kvm", 124, true, true },
+                                             { "4.2.1", "native", 137, false, true },
+                                             { "4.2.3", "native", 138, true, true } };
 
 static PlaygroundConfig legacy_config = { "4.2.1-121.kvm",
                                           legacy_kernels,
@@ -143,7 +143,7 @@ END_TEST
 START_TEST(bootman_legacy_update_from_unknown)
 {
         autofree(BootManager) *m = NULL;
-        PlaygroundKernel kernels[] = { { "4.2.1", "kvm", 121, true } };
+        PlaygroundKernel kernels[] = { { "4.2.1", "kvm", 121, true, true } };
         PlaygroundConfig config = { "4.2.1-121.kvm", kernels, 1, false };
         autofree(KernelArray) *pre_kernels = NULL;
         autofree(KernelArray) *post_kernels = NULL;

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -234,7 +234,7 @@ START_TEST(bootman_uefi_remove_bootloader)
         autofree(BootManager) *m = NULL;
 
         fail_if(!nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                              "/EFI/Boot"),
+                                              "/efi/BOOT"),
                 "Main EFI directory missing, botched install");
 
         m = prepare_playground(&uefi_config);
@@ -252,19 +252,19 @@ START_TEST(bootman_uefi_remove_bootloader)
 
         /* Ensure that it is indeed removed. */
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground" BOOT_DIRECTORY
-                                             "/EFI/Boot/" DEFAULT_EFI_BLOB),
+                                             "/efi/BOOT" DEFAULT_EFI_BLOB),
                 "Main x64 bootloader present");
 #if defined(HAVE_SYSTEMD_BOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/systemd"),
+                                             "/efi/systemd"),
                 "Systemd x64 bootloader present");
 #elif defined(HAVE_GUMMIBOOT)
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/gummiboot"),
+                                             "/efi/gummiboot"),
                 "gummiboot x64 bootloader present");
 #else
         fail_if(nc_file_exists(TOP_BUILD_DIR "/tests/update_playground/" BOOT_DIRECTORY
-                                             "/EFI/goofiboot"),
+                                             "/efi/goofiboot"),
                 "goofiboot x64 bootloader present");
 #endif
 

--- a/tests/check-uefi.c
+++ b/tests/check-uefi.c
@@ -154,7 +154,7 @@ START_TEST(bootman_uefi_update_from_unknown)
         /* Check running kernel */
         running_kernel = boot_manager_get_running_kernel(m, post_kernels);
         fail_if(!running_kernel, "Failed to find kernel post reboot");
-        fail_if(!streq(running_kernel->version, "4.2.1"), "Running kernel is invalid");
+        fail_if(!streq(running_kernel->meta.version, "4.2.1"), "Running kernel is invalid");
 }
 END_TEST
 

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -438,25 +438,45 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 
         autofree(char) *conf_file = NULL;
         autofree(char) *kernel_blob = NULL;
+        autofree(char) *kernel_blob_legacy = NULL;
         autofree(char) *initrd_file = NULL;
+        autofree(char) *initrd_file_legacy = NULL;
         const char *vendor = NULL;
         int file_count = 0;
 
         vendor = boot_manager_get_vendor_prefix(manager);
 
-        kernel_blob = string_printf("%s/%s.%s.%s-%d",
+        kernel_blob = string_printf("%s/efi/%s/kernel-%s.%s.%s-%d",
                                     BOOT_FULL,
+                                    KERNEL_NAMESPACE,
                                     KERNEL_NAMESPACE,
                                     kernel->ktype,
                                     kernel->version,
                                     kernel->release);
 
-        initrd_file = string_printf("%s/initrd-%s.%s.%s-%d",
+        /* Old name, pre namespace change */
+        kernel_blob_legacy = string_printf("%s/%s.%s.%s-%d",
+                                           BOOT_FULL,
+                                           KERNEL_NAMESPACE,
+                                           kernel->ktype,
+                                           kernel->version,
+                                           kernel->release);
+
+        initrd_file = string_printf("%s/efi/%s/initrd-%s.%s.%s-%d",
                                     BOOT_FULL,
+                                    KERNEL_NAMESPACE,
                                     KERNEL_NAMESPACE,
                                     kernel->ktype,
                                     kernel->version,
                                     kernel->release);
+
+        /* Old name, pre namespace change */
+        initrd_file_legacy = string_printf("%s/initrd-%s.%s.%s-%d",
+                                           BOOT_FULL,
+                                           KERNEL_NAMESPACE,
+                                           kernel->ktype,
+                                           kernel->version,
+                                           kernel->release);
 
         conf_file = string_printf("%s/loader/entries/%s-%s-%s-%d.conf",
                                   BOOT_FULL,
@@ -465,14 +485,24 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
                                   kernel->version,
                                   kernel->release);
 
-        if (nc_file_exists(kernel_blob)) {
-                ++file_count;
-        }
         if (nc_file_exists(conf_file)) {
                 ++file_count;
         }
-        if (nc_file_exists(initrd_file)) {
-                ++file_count;
+
+        if (kernel->legacy_name) {
+                if (nc_file_exists(kernel_blob_legacy)) {
+                        ++file_count;
+                }
+                if (nc_file_exists(initrd_file_legacy)) {
+                        ++file_count;
+                }
+        } else {
+                if (nc_file_exists(kernel_blob)) {
+                        ++file_count;
+                }
+                if (nc_file_exists(initrd_file)) {
+                        ++file_count;
+                }
         }
         return file_count;
 }

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -48,11 +48,11 @@
  */
 #define BOOT_FULL PLAYGROUND_ROOT "/" BOOT_DIRECTORY
 
-#define EFI_START BOOT_FULL "/EFI"
+#define EFI_START BOOT_FULL "/efi"
 /**
  * i.e. $dir/EFI/Boot/BOOTX64.EFI
  */
-#define EFI_STUB_MAIN BOOT_FULL "/EFI/Boot/BOOT" EFI_STUB_SUFFIX
+#define EFI_STUB_MAIN BOOT_FULL "/efi/BOOT/BOOT" EFI_STUB_SUFFIX
 
 /**
  * Places that need to exist..
@@ -388,11 +388,18 @@ BootManager *prepare_playground(PlaygroundConfig *config)
                 goto fail;
         }
 
+        if (!boot_manager_set_boot_dir(m, PLAYGROUND_ROOT "/" BOOT_DIRECTORY)) {
+                goto fail;
+        }
+
         /* Copy the bootloader bits into the tree */
         if (config->uefi) {
                 if (!push_bootloader_update(0)) {
                         goto fail;
                 }
+                /* Create dir *after* init to simulate ESP mount behaviour with
+                 * a different-case boot tree on the ESP */
+                fail_if(!nc_mkdir_p(EFI_START "/BOOT", 00755), "Failed to create boot structure");
         } else {
                 push_syslinux();
         }

--- a/tests/harness.c
+++ b/tests/harness.c
@@ -480,7 +480,7 @@ int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel)
 bool confirm_kernel_installed(BootManager *manager, PlaygroundConfig *config,
                               PlaygroundKernel *kernel)
 {
-        return kernel_installed_files_count(manager, kernel) == config->uefi ? 3 : 2;
+        return kernel_installed_files_count(manager, kernel) == (config->uefi ? 3 : 2);
 }
 
 bool confirm_kernel_uninstalled(BootManager *manager, PlaygroundKernel *kernel)

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -24,6 +24,7 @@ typedef struct PlaygroundKernel {
         const char *ktype;
         int release;
         bool default_for_type;
+        bool legacy_name; /**<UEFI specific */
 } PlaygroundKernel;
 
 /**
@@ -73,6 +74,11 @@ bool push_bootloader_update(int revision);
  * Util - confirm the bootloader is installed in the current test
  */
 void confirm_bootloader(void);
+
+/**
+ * Accumulate potential installed files for a given kernel
+ */
+int kernel_installed_files_count(BootManager *manager, PlaygroundKernel *kernel);
 
 /**
  * Util - confirm the bootloader installed matches the source file


### PR DESCRIPTION
 - Validate that we're able to cope with case-ignorance on FAT32 by deliberately mangling the test paths
 - Reinit bootloader to allow this to work with newly mounted ESP
 - Significantly reduce duplication by restructuring the `Kernel` type to internally namespace. Drops much of the `basename` usage
 - Fix a couple of bugs with the `harness`, and within `syslinux`
 - Implement full UEFI namespacing in preparation for secure boot enabling (`/EFI/org.clearlinux`, for example.)

Next PR will be looking to seal the deal, by adding:

 - `GPT` detection for syslinux-conditionals (via `/boot` probe)
 - GRUB2 support (`!syslinux`/legacy, for configuration files **only**)