### PR TITLE
Add GRUB2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ check_legacy
 check_files
 check_os_release
 check_uefi
+check_grub2
 
 *.log
 *.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ libcbm_la_SOURCES =			\
 	src/bootloaders/systemd-class.h \
 	src/bootloaders/systemd-class.c \
 	src/bootloaders/systemd-boot.c	\
+	src/bootloaders/grub2.c		\
 	src/bootloaders/gummiboot.c	\
 	src/bootloaders/goofiboot.c	\
 	src/bootloaders/syslinux.c	\
@@ -157,7 +158,8 @@ TESTS = 		\
 	check_files 	\
 	check_legacy    \
 	check_os_release \
-	check_uefi
+	check_uefi 	\
+	check_grub2
 
 check_PROGRAMS = $(TESTS)
 
@@ -254,6 +256,24 @@ check_uefi_CFLAGS =		\
 	$(AM_CFLAGS)
 
 check_uefi_LDADD =	\
+	libcbm.la	\
+	src/libnica/libnica.la	\
+	$(BLKID_LIBS)	\
+	$(CHECK_LIBS)
+
+check_grub2_SOURCES = \
+	tests/check-grub2.c 	\
+	tests/blkid-harness.h   \
+	tests/system-harness.h  \
+	tests/harness.h		\
+	tests/harness.c
+
+check_grub2_CFLAGS =		\
+	$(BLKID_CFLAGS)		\
+	$(CHECK_CFLAGS)		\
+	$(AM_CFLAGS)
+
+check_grub2_LDADD =	\
 	libcbm.la	\
 	src/libnica/libnica.la	\
 	$(BLKID_LIBS)	\

--- a/README.md
+++ b/README.md
@@ -5,24 +5,61 @@ clr-boot-manager
 [![Coverage Status](https://coveralls.io/repos/github/ikeydoherty/clr-boot-manager/badge.png?branch=master)](https://coveralls.io/github/ikeydoherty/clr-boot-manager?branch=master)
 
 
-clr-boot-manager  exists  to  enable the correct maintainence of vendor
-kernels and appropriate garbage collection tactics over the  course  of
-upgrades.   The  implementation  provides  the  means to enable correct
-cohabitation on a shared boot directory, such as the EFI System  Partition
-for UEFI-booting operating systems.
+clr-boot-manager  exists  to  enable the correct maintenance of vendor kernels and appropriate garbage collection tactics over the  course  of upgrades.   The  implementation  provides  the  means to enable correct cohabitation on a shared boot directory, such as the EFI System  Partition for UEFI-booting operating systems.
 
-Special  care  is taken to ensure the ESP is handled gracefully, and in
-the instance that it is not already mounted, then clr-boot-manager will
-automatically  discover and mount it, and automatically unmount the ESP
-again when it is complete.
+Special  care  is taken to ensure the boot partition is handled gracefully, and in the instance that it is not already mounted, then clr-boot-manager will automatically  discover and mount it, and automatically unmount the boot partition again when it is complete.
+
+Most importantly, clr-boot-manager provides a simple mechanism to provide kernel updates, with the ability for users to rollback to an older kernel should the new update be problematic. This is achieved through the use of strict namespace policies, permanent source paths, and clr-boot-manager's own internal logic, without the need for "meta packages" or undue complexity on the distribution side.
 
 Requirements
 ------------
 
-clr-boot-manager is designed to operate solely with `GPT` disks, and
-exclusively uses `PARTUUID`. Generated boot entries also contain the `PARTUUID`
-in their `root=` command line, as part of a merge of the vendor provided
-`cmdline` files for default options.
+clr-boot-manager is primarily designed for GPT disks using UEFI, however it does contain fallback support for legacy bootloaders such as GRUB2 to allow all users to benefit from automated kernel management.
+
+clr-boot-manager should be the only tool responsible within the OS for generating boot entries, and will automatically incorporate the correct `root=` portions.
+
+Kernel Integration
+------------------
+
+The way that a kernel is packaged changes significantly with clr-boot-manager. First and foremost, no files shall be shipped in `/boot`. The distribution should choose a namespace to identify their system in dual-boot situations, i.e:
+
+    org.someproject
+
+All paths known to CBM must have follow a specific format and encoding, whereby
+the version, release number, and *type* are encoded:
+
+    /usr/lib/kernel
+     -> config-4.9.17-9.lts
+     -> org.someproject.lts.4.9.17-9
+     -> System.map-4.9.17-9.lts
+     -> cmdline-4.9.17-9.lts
+     -> initrd-org.someproject.lts.4.9.17-9 (Optional)
+    /usr/src/linux-headers-4.9.17-9.lts
+    /usr/lib/modules/4.9.17-9.lts
+
+The directories can be altered via the `./configure` options. See `./configure --help` for further details.
+
+Additionally, each kernel shall be compiled with the versioning information built
+in, which can be achieved by doing something similar to this in the build spec:
+
+    extraVersion="-${release}.lts"
+    sed -e "s/EXTRAVERSION =.*/EXTRAVERSION = $extraVersion/" -i Makefile
+
+This results in an easily identifiable `uname` which CBM can use to manage kernels:
+
+
+    $ uname -a
+    Linux some-host 4.9.17-9.lts #1 SMP Wed Mar 22 16:02:52 UTC 2017 x86_64 GNU/Linux
+
+The `initrd` file should be shipped with the kernel package itself, built for a generic target. This minimises the errors that can happen when having a non reproducible command. Users may override the initrd by providing the same filename within `/etc/kernel`.
+
+All of the above paths should be marked as resident/permanent in the software deployment mechanism as they will be automatically destroyed when clr-boot-manager performs the garbage collection cycle. Note that each "type" of kernel is up to the distribution to define, however it should be alphabetical only with no dots or hyphens.
+
+The next "default" kernel (i.e. tip for a given series) is defined with the `symlink-$(type)` notation, and allows clr-boot-manager to know that a kernel is not yet up to date. No version comparison is performed, ensuring that the symlink is always the source of information:
+
+`/usr/lib/kernel/default-lts: symbolic link to org.someproject.lts.4.9.17-9`
+
+The "post install" step for a kernel shall call `clr-boot-manager update` to push the new configuration & updates to disk. This can be called multiple times, as clr-boot-manager will only update exactly what needs to be updated, saving unnecessary writes to the ESP or `/boot` partition.
 
 License
 -------

--- a/src/bootloaders/grub2.c
+++ b/src/bootloaders/grub2.c
@@ -1,0 +1,406 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016-2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+/**
+ * Remove /vmlinuz & /initrd.img
+ * Create /etc/grub.d/10_$nom
+ * Run grub-mkconfig -o /boot/grub/grub.cfg
+ * Recreate symlinks for default
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "bootloader.h"
+#include "config.h"
+#include "files.h"
+#include "log.h"
+#include "nica/files.h"
+#include "system_stub.h"
+#include "util.h"
+#include "writer.h"
+
+/**
+ * Inspired by/modelled on, /etc/grub.d/10_linux
+ * Each CBM entry is a unique script, so there is no caching between multiple
+ * entries.
+ */
+#define GRUB2_10LINUX_CACHE                                                                        \
+        "\
+        if [[ \"${dirname}\" = \"/\" ]]; then\n\
+                prep_root=\"$(prepare_grub_to_access_device ${GRUB_DEVICE})\"\n\
+                printf '\t%s\\n' \"${prep_root}\"\n\
+        else\n\
+                prep_root=\"$(prepare_grub_to_access_device ${GRUB_DEVICE_BOOT})\"\n\
+                printf '\t%s\\n' \"${prep_root}\"\n\
+        fi\n\
+"
+
+/**
+ * Form the full path to the GRUB2 configuration script
+ */
+static inline char *grub2_get_entry_path_for_kernel(BootManager *manager, const Kernel *kernel)
+{
+        return string_printf("%s/etc/grub.d/10_%s_%s-%d.%s",
+                             boot_manager_get_prefix(manager),
+                             boot_manager_get_os_id(manager),
+                             kernel->meta.version,
+                             kernel->meta.release,
+                             kernel->meta.ktype);
+}
+
+/**
+ * If /boot is mounted, we already now know its a separate boot partition, so
+ * accommodate for it.
+ */
+static inline bool grub2_is_separate_boot_partition(void)
+{
+        return cbm_system_is_mounted(BOOT_DIRECTORY);
+}
+
+/**
+ * Return relative dir, i.e. instead of /boot, boot
+ */
+static inline char *grub2_get_boot_relative(void)
+{
+        static char *grub_bootdir = BOOT_DIRECTORY;
+        return string_printf("%s", grub_bootdir + 1);
+}
+
+bool grub2_init(__cbm_unused__ const BootManager *manager)
+{
+        return true;
+}
+
+void grub2_destroy(__cbm_unused__ const BootManager *manager)
+{
+}
+
+bool grub2_install_kernel(const BootManager *manager, const Kernel *kernel)
+{
+        if (!manager || !kernel) {
+                return false;
+        }
+
+        autofree(CbmWriter) *writer = CBM_WRITER_INIT;
+        autofree(char) *grub_dir = NULL;
+        const CbmDeviceProbe *root_dev = NULL;
+        const char *os_name = NULL;
+        const char *os_id = NULL;
+        autofree(char) *old_conf = NULL;
+        autofree(char) *conf_path = NULL;
+        autofree(char) *boot_dir = NULL;
+        const char *prefix = NULL;
+        bool is_separate;
+
+        if (!cbm_writer_open(writer)) {
+                return false;
+        }
+
+        prefix = boot_manager_get_prefix((BootManager *)manager);
+
+        root_dev = boot_manager_get_root_device((BootManager *)manager);
+        if (!root_dev) {
+                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->source.path);
+                return false;
+        }
+
+        is_separate = grub2_is_separate_boot_partition();
+        boot_dir = grub2_get_boot_relative();
+
+        os_name = boot_manager_get_os_name((BootManager *)manager);
+        os_id = boot_manager_get_os_id((BootManager *)manager);
+
+        /* Write out the stock header for our script */
+        cbm_writer_append(writer, "#!/bin/bash\nset -e\n");
+        cbm_writer_append(writer, ". \"/usr/share/grub/grub-mkconfig_lib\"\n");
+
+        /* Write the start of the entry
+         * e.g. menuentry 'Some Linux OS (4.4.9-12.lts)' --class some-linux-os --class gnu-linux
+         * --class gnu --class os
+         */
+        cbm_writer_append_printf(
+            writer,
+            "echo \"menuentry '%s (%s-%d.%s)' --class %s --class gnu-linux --class gnu --class os",
+            os_name,
+            kernel->meta.version,
+            kernel->meta.release,
+            kernel->meta.ktype,
+            os_id);
+        /* Finish it off with a unique menu ID and escape the bash variable */
+        cbm_writer_append_printf(writer,
+                                 " \\$menuentry_id_option '%s-%s-%d.%s' {\"\n",
+                                 os_id,
+                                 kernel->meta.version,
+                                 kernel->meta.release,
+                                 kernel->meta.ktype);
+
+        /* Load video, compatibility with 10_linux */
+        cbm_writer_append(writer, "\tif [ \"x$GRUB_GFXPAYLOAD_LINUX\" = x ]; then\n");
+        cbm_writer_append(writer, "\t\techo \"\tload_video\"\n");
+        cbm_writer_append(writer, "\tfi\n");
+
+        /* Always load gzio */
+        cbm_writer_append(writer, "echo \"\tinsmod gzio\"\n");
+
+        const char *cache = GRUB2_10LINUX_CACHE;
+        cbm_writer_append(writer, cache);
+
+        /* Add the main loader lines */
+        cbm_writer_append_printf(writer,
+                                 "echo \"\techo 'Loading %s %s ...'\"\n",
+                                 os_name,
+                                 kernel->meta.version);
+        if (is_separate) {
+                cbm_writer_append_printf(writer,
+                                         "echo \"\tlinux /%s root=UUID=%s ",
+                                         kernel->target.legacy_path,
+                                         root_dev->uuid);
+        } else {
+                cbm_writer_append_printf(writer,
+                                         "echo \"\tlinux %s/%s root=UUID=%s ",
+                                         BOOT_DIRECTORY, /* i.e. /boot */
+                                         kernel->target.legacy_path,
+                                         root_dev->uuid);
+        }
+
+        if (root_dev->luks_uuid) {
+                cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
+        }
+
+        /* Finish it off with the command line options */
+        cbm_writer_append_printf(writer, "%s\"\n", kernel->meta.cmdline);
+
+        /* Optional initrd */
+        if (kernel->target.initrd_path) {
+                cbm_writer_append(writer, "echo \"\techo 'Loading initial ramdisk'\"\n");
+                if (is_separate) {
+                        cbm_writer_append_printf(writer,
+                                                 "echo \"\tinitrd /%s\"\n",
+                                                 kernel->target.initrd_path);
+                } else {
+                        cbm_writer_append_printf(writer,
+                                                 "echo \"\tinitrd %s/%s\"\n",
+                                                 BOOT_DIRECTORY, /* i.e. /boot */
+                                                 kernel->target.initrd_path);
+                }
+        }
+
+        /* Finalize the entry */
+        cbm_writer_append(writer, "echo \"}\"\n");
+
+        cbm_writer_close(writer);
+
+        conf_path = grub2_get_entry_path_for_kernel((BootManager *)manager, kernel);
+
+        /* If our new config matches the old config, just return. */
+        if (file_get_text(conf_path, &old_conf)) {
+                if (streq(old_conf, writer->buffer)) {
+                        return true;
+                }
+        }
+
+        /* Ensure the grub.d directory actually exists (should do..) */
+        grub_dir = string_printf("%s/etc/grub.d", prefix);
+        if (!nc_file_exists(grub_dir) && !nc_mkdir_p(grub_dir, 00755)) {
+                LOG_FATAL("Failed to create grub.d dir: %s [%s]", grub_dir, strerror(errno));
+                return false;
+        }
+
+        if (!file_set_text(conf_path, writer->buffer)) {
+                LOG_FATAL("Failed to create loader entry for: %s [%s]",
+                          kernel->source.path,
+                          strerror(errno));
+                return false;
+        }
+
+        /* Ensure it's executable */
+        if (chmod(conf_path, 00755) != 0) {
+                LOG_FATAL("Failed to mark loader entry as executable: %s [%s]",
+                          kernel->source.path,
+                          strerror(errno));
+                return false;
+        }
+
+        cbm_sync();
+
+        return true;
+}
+
+bool grub2_remove_kernel(const BootManager *manager, const Kernel *kernel)
+{
+        if (!manager || !kernel) {
+                return false;
+        }
+        autofree(char) *conf_path = NULL;
+
+        conf_path = grub2_get_entry_path_for_kernel((BootManager *)manager, kernel);
+        if (nc_file_exists(conf_path) && unlink(conf_path) < 0) {
+                LOG_FATAL("grub2_remove_kernel: Failed to remove %s: %s",
+                          conf_path,
+                          strerror(errno));
+                return false;
+        }
+        return true;
+}
+
+bool grub2_set_default_kernel(const BootManager *manager, const Kernel *default_kernel)
+{
+        if (!manager) {
+                return false;
+        }
+        autofree(char) *vmlinuz_path = NULL;
+        autofree(char) *initrd_path = NULL;
+        autofree(char) *command = NULL;
+        autofree(char) *boot_dir = NULL;
+        autofree(char) *grub_dir = NULL;
+        autofree(char) *vmlinuz_rel = NULL;
+        autofree(char) *initrd_rel = NULL;
+        autofree(char) *boot_rel = NULL;
+        const char *prefix = NULL;
+        int ret;
+
+        prefix = boot_manager_get_prefix((BootManager *)manager);
+        boot_dir = boot_manager_get_boot_dir((BootManager *)manager);
+        vmlinuz_path = string_printf("%s/vmlinuz", prefix);
+        initrd_path = string_printf("%s/initrd.img", prefix);
+
+        /* Always nuke the files *before* running grub-mkconfig to stop duped
+         * entries being created */
+        if (nc_file_exists(vmlinuz_path) && unlink(vmlinuz_path) < 0) {
+                LOG_ERROR("grub2_set_default_kernel: Failed to remove %s: %s",
+                          vmlinuz_path,
+                          strerror(errno));
+                return false;
+        }
+
+        if (nc_file_exists(initrd_path) && unlink(initrd_path) < 0) {
+                LOG_FATAL("grub2_set_default_kernel: Failed to remove %s: %s",
+                          initrd_path,
+                          strerror(errno));
+                return false;
+        }
+
+        /* Ensure the GRUB2 directory tree exists */
+        grub_dir = string_printf("%s/grub", boot_dir);
+        if (!nc_file_exists(grub_dir) && !nc_mkdir_p(grub_dir, 00755)) {
+                LOG_FATAL("grub2_set_default_kernel: Failed to mkdir %s: %s",
+                          grub_dir,
+                          strerror(errno));
+                return false;
+        }
+
+        /* Run grub-mkconfig now */
+        command = string_printf("%s/usr/sbin/grub-mkconfig -o %s/grub/grub.cfg", prefix, boot_dir);
+        ret = cbm_system_system(command);
+        if (ret != 0) {
+                LOG_FATAL("grub2_set_default_kernel: grub-mkconfig exited with status code %d: %s",
+                          ret,
+                          strerror(errno));
+                return false;
+        }
+
+        /* Nothing else to do here */
+        if (!default_kernel) {
+                return true;
+        }
+
+        /* i.e. boot */
+        boot_rel = grub2_get_boot_relative();
+
+        /* /vmlinuz -> boot/kernel-* */
+        vmlinuz_rel = string_printf("%s/%s", boot_rel, default_kernel->target.legacy_path);
+        if (symlink(vmlinuz_rel, vmlinuz_path) != 0) {
+                LOG_FATAL("grub2_set_default_kernel: Failed to update kernel default link: %s",
+                          strerror(errno));
+                return false;
+        }
+
+        /* No initrd, just continue */
+        if (!default_kernel->target.initrd_path) {
+                return true;
+        }
+
+        /* /initrd.img -> boot/initrd-* */
+        initrd_rel = string_printf("%s/%s", boot_rel, default_kernel->target.initrd_path);
+        if (symlink(initrd_rel, initrd_path) != 0) {
+                LOG_FATAL("grub2_set_default_kernel: Failed to update initrd default link: %s",
+                          strerror(errno));
+                return false;
+        }
+
+        return true;
+}
+
+bool grub2_needs_install(__cbm_unused__ const BootManager *manager)
+{
+        return false;
+}
+
+bool grub2_needs_update(__cbm_unused__ const BootManager *manager)
+{
+        return false;
+}
+
+bool grub2_install(__cbm_unused__ const BootManager *manager)
+{
+        /* We don't handle management of GRUB2 so we just say, yes, it did
+         * install. This saves complications.
+         */
+        return true;
+}
+
+bool grub2_update(__cbm_unused__ const BootManager *manager)
+{
+        /* Likewise, we don't update. Just return true. */
+        return true;
+}
+
+bool grub2_remove(__cbm_unused__ const BootManager *manager)
+{
+        /* Certainly not going to remove if we don't install */
+        return true;
+}
+
+int grub2_get_capabilities(__cbm_unused__ const BootManager *manager)
+{
+        /* Or in other words, we're the last bootloader candidate. */
+        return BOOTLOADER_CAP_LEGACY;
+}
+
+__cbm_export__ const BootLoader grub2_bootloader = {.name = "grub2",
+                                                    .init = grub2_init,
+                                                    .install_kernel = grub2_install_kernel,
+                                                    .remove_kernel = grub2_remove_kernel,
+                                                    .set_default_kernel = grub2_set_default_kernel,
+                                                    .needs_install = grub2_needs_install,
+                                                    .needs_update = grub2_needs_update,
+                                                    .install = grub2_install,
+                                                    .update = grub2_update,
+                                                    .remove = grub2_remove,
+                                                    .destroy = grub2_destroy,
+                                                    .get_capabilities = grub2_get_capabilities };
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -30,6 +30,7 @@
 /**
  * Total "usable" bootloaders
  */
+extern const BootLoader grub2_bootloader;
 extern const BootLoader systemd_bootloader;
 extern const BootLoader gummiboot_bootloader;
 extern const BootLoader goofiboot_bootloader;
@@ -38,17 +39,17 @@ extern const BootLoader syslinux_bootloader;
 /**
  * Bootloader set that we're allowed to check and use
  */
-const BootLoader *bootman_known_loaders[] = {
+const BootLoader *bootman_known_loaders[] =
+    { &grub2_bootloader, /**<Always place first to allow syslinux to override */
 #if defined(HAVE_SYSTEMD_BOOT)
-        &systemd_bootloader,
+      &systemd_bootloader,
 #elif defined(HAVE_GUMMIBOOT)
-        &gummiboot_bootloader,
+      &gummiboot_bootloader,
 #else
-        &goofiboot_bootloader,
+      &goofiboot_bootloader,
 #endif
-        /* non-systemd-class */
-        &syslinux_bootloader
-};
+      /* non-systemd-class */
+      &syslinux_bootloader };
 
 BootManager *boot_manager_new()
 {
@@ -222,6 +223,14 @@ const char *boot_manager_get_os_name(BootManager *self)
         assert(self->os_release != NULL);
 
         return cbm_os_release_get_value(self->os_release, OS_RELEASE_PRETTY_NAME);
+}
+
+const char *boot_manager_get_os_id(BootManager *self)
+{
+        assert(self != NULL);
+        assert(self->os_release != NULL);
+
+        return cbm_os_release_get_value(self->os_release, OS_RELEASE_ID);
 }
 
 const CbmDeviceProbe *boot_manager_get_root_device(BootManager *self)

--- a/src/bootman/bootman.c
+++ b/src/bootman/bootman.c
@@ -97,16 +97,9 @@ void boot_manager_free(BootManager *self)
 
 static bool boot_manager_select_bootloader(BootManager *self)
 {
-        int wanted_boot_mask = 0;
         const BootLoader *selected = NULL;
         int selected_boot_mask = 0;
-
-        /* Find legacy */
-        if (self->sysconfig->legacy) {
-                wanted_boot_mask |= BOOTLOADER_CAP_LEGACY;
-        } else {
-                wanted_boot_mask |= BOOTLOADER_CAP_UEFI;
-        }
+        int wanted_boot_mask = self->sysconfig->wanted_boot_mask;
 
         /* Select a bootloader based on the capabilities */
         for (size_t i = 0; i < ARRAY_SIZE(bootman_known_loaders); i++) {

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -181,6 +181,13 @@ void boot_manager_set_os_name(BootManager *manager, char *os_name);
 const char *boot_manager_get_os_name(BootManager *manager);
 
 /**
+ * Return the OS ID (used in class values)
+ *
+ * @note This string is owned by BootManager, do not modify or free
+ */
+const char *boot_manager_get_os_id(BootManager *self);
+
+/**
  * Discover a list of known kernels
  *
  * @return a newly allocated NcArray of Kernel's

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -84,7 +84,7 @@ typedef struct SystemConfig {
         char *prefix;                /**<Prefix for all operations */
         CbmDeviceProbe *root_device; /**<The physical root device */
         char *boot_device;           /**<The physical boot device */
-        bool legacy;                 /**<Legacy or UEFI */
+        int wanted_boot_mask;        /**<The required bootloader mask */
 } SystemConfig;
 
 /**

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -64,6 +64,7 @@ typedef struct Kernel {
                 char *user_initrd_file; /**<User's initrd file */
                 char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
                 char *module_dir;       /**<Path to the modules directory */
+                char *sysmap_file;      /**<Path to the System.map file */
         } source;
 
         /* Target (basename) paths */

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -65,6 +65,7 @@ typedef struct Kernel {
                 char *kboot_file;       /**<Path to the k_booted_$(uname -r) file */
                 char *module_dir;       /**<Path to the modules directory */
                 char *sysmap_file;      /**<Path to the System.map file */
+                char *headers_dir;      /**<Path to the kernels header directory */
         } source;
 
         /* Target (basename) paths */

--- a/src/bootman/update.c
+++ b/src/bootman/update.c
@@ -59,7 +59,7 @@ bool boot_manager_update(BootManager *self)
 
         /* TODO: decide how legacy device detection works */
         /* For now legacy means /boot is on the / partition */
-        if (self->sysconfig->legacy) {
+        if ((self->sysconfig->wanted_boot_mask & BOOTLOADER_CAP_LEGACY) == BOOTLOADER_CAP_LEGACY) {
                 LOG_DEBUG("Skipping to legacy-native-install (no mount)");
                 goto perform;
         }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -77,8 +77,8 @@ static bool print_version(__cbm_unused__ int argc, __cbm_unused__ char **argv)
 \n\
 Copyright \u00A9 2016-2017 Intel Corporation\n\n\
 " PACKAGE_NAME " is free software; you can redistribute it and/or modify\n\
-it under the terms of the GNU General Public License as published by\n\
-the Free Software Foundation; either version 2 of the License, or\n\
+it under the terms of the GNU Lesser General Public License as published by\n\
+the Free Software Foundation; either version 2.1 of the License, or\n\
 (at your option) any later version.\n");
         return true;
 }

--- a/src/lib/files.c
+++ b/src/lib/files.c
@@ -84,7 +84,7 @@ char *get_boot_device()
         char read_buf[4096];
         glo.gl_offs = 1;
         int fd = -1;
-        ;
+
         ssize_t size = 0;
         autofree(char) *uuid = NULL;
         autofree(char) *p = NULL;

--- a/src/lib/os-release.c
+++ b/src/lib/os-release.c
@@ -10,6 +10,7 @@
  */
 
 #include "os-release.h"
+#include "config.h"
 #include "log.h"
 #include "nica/files.h"
 
@@ -44,6 +45,8 @@ static const char *cbm_os_release_fallback_value(CbmOsReleaseKey key)
         case OS_RELEASE_PRETTY_NAME:
                 return "generic-linux-os";
         case OS_RELEASE_ID:
+                /* Similar purpose within CBM */
+                return VENDOR_PREFIX;
         case OS_RELEASE_VERSION:
         case OS_RELEASE_VERSION_ID:
                 return "1";

--- a/tests/check-grub2.c
+++ b/tests/check-grub2.c
@@ -1,0 +1,235 @@
+/*
+ * This file is part of clr-boot-manager.
+ *
+ * Copyright © 2016-2017 Intel Corporation
+ *
+ * clr-boot-manager is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ */
+
+#define _GNU_SOURCE
+#include <check.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "bootman.h"
+#include "config.h"
+#include "files.h"
+#include "log.h"
+#include "nica/array.h"
+#include "nica/files.h"
+#include "util.h"
+#include "writer.h"
+
+#include "blkid-harness.h"
+#include "harness.h"
+#include "system-harness.h"
+
+#define PLAYGROUND_ROOT TOP_BUILD_DIR "/tests/update_playground"
+
+/**
+ * We only permit UUID in our tests.
+ */
+static int grub2_blkid_probe_lookup_value(__cbm_unused__ blkid_probe pr, const char *name,
+                                          const char **data, size_t *len)
+{
+        if (!name || !data) {
+                return -1;
+        }
+        if (streq(name, "UUID")) {
+                *data = DEFAULT_UUID;
+        } else {
+                return -1;
+        }
+        if (!*data) {
+                abort();
+        }
+        if (len) {
+                *len = strlen(*data);
+        }
+        return 0;
+}
+
+static PlaygroundKernel grub2_kernels[] = { { "4.2.1", "kvm", 121, false, true },
+                                            { "4.2.3", "kvm", 124, true, true },
+                                            { "4.2.1", "native", 137, false, true },
+                                            { "4.2.3", "native", 138, true, true } };
+
+static PlaygroundConfig grub2_config = { "4.2.1-121.kvm",
+                                         grub2_kernels,
+                                         ARRAY_SIZE(grub2_kernels),
+                                         .uefi = false };
+
+#define PLAYGROUND_ROOT TOP_BUILD_DIR "/tests/update_playground"
+
+START_TEST(bootman_grub2_get_boot_device)
+{
+        autofree(char) *boot_device = NULL;
+        autofree(BootManager) *m = NULL;
+        autofree(char) *exp = NULL;
+
+        /* Ensure cleanup */
+        m = prepare_playground(&grub2_config);
+
+        boot_device = get_boot_device();
+        fail_if(boot_device != NULL, "Found incorrect device for Legacy (GRUB2) Boot");
+}
+END_TEST
+
+START_TEST(bootman_grub2_image)
+{
+        autofree(BootManager) *m = NULL;
+        m = prepare_playground(&grub2_config);
+        fail_if(!m, "Failed to prepare update playground");
+
+        /* Validate image install */
+        boot_manager_set_image_mode(m, true);
+        fail_if(!boot_manager_update(m), "Failed to update image");
+}
+END_TEST
+
+START_TEST(bootman_grub2_native)
+{
+        autofree(BootManager) *m = NULL;
+
+        m = prepare_playground(&grub2_config);
+        fail_if(!m, "Failed to prepare update playground");
+        boot_manager_set_image_mode(m, false);
+
+        fail_if(!set_kernel_booted(&grub2_kernels[1], true), "Failed to set kernel as booted");
+
+        fail_if(!boot_manager_update(m), "Failed to update in native mode");
+
+        /* Latest kernel for us */
+        fail_if(!confirm_kernel_installed(m, &grub2_config, &(grub2_kernels[0])),
+                "Newest kernel not installed");
+
+        /* Running kernel */
+        fail_if(!confirm_kernel_installed(m, &grub2_config, &(grub2_kernels[1])),
+                "Newest kernel not installed");
+
+        /* This guy isn't supposed to be kept around now */
+        fail_if(!confirm_kernel_uninstalled(m, &(grub2_kernels[2])),
+                "Uninteresting kernel shouldn't be kept around.");
+}
+END_TEST
+
+/**
+ * This test is designed to perform a system update to a new kernel, when the
+ * current kernel cannot be detected. This ensures we can perform a transition
+ * from a non cbm-managed distro to a cbm-managed one.
+ *
+ * Scenario:
+ *
+ *      - Unknown running kernel
+ *      - One initial new kernel from the first update. Has never rebooted.
+ *      - Update: New kernel should be installed
+ *      - "Reboot", then verify running = only kernel on system
+ */
+START_TEST(bootman_grub2_update_from_unknown)
+{
+        autofree(BootManager) *m = NULL;
+        PlaygroundKernel kernels[] = { { "4.2.1", "kvm", 121, true, true } };
+        PlaygroundConfig config = { "4.2.1-121.kvm", kernels, 1, false };
+        autofree(KernelArray) *pre_kernels = NULL;
+        autofree(KernelArray) *post_kernels = NULL;
+        Kernel *running_kernel = NULL;
+
+        m = prepare_playground(&config);
+        fail_if(!m, "Failed to prepare update playground");
+        boot_manager_set_image_mode(m, false);
+
+        /* Hax the uname */
+        boot_manager_set_uname(m, "unknown-uname");
+
+        /* Make sure pre kernels are found */
+        pre_kernels = boot_manager_get_kernels(m);
+        fail_if(!pre_kernels, "Failed to find kernels");
+        fail_if(pre_kernels->len != 1, "Available kernels != 1");
+
+        /* Ensure it's not booting */
+        fail_if(boot_manager_get_running_kernel(m, pre_kernels) != NULL,
+                "Should not find a running kernel at this point");
+
+        /* Attempt update in this configuration */
+        fail_if(!boot_manager_update(m), "Failed to update single kernel system");
+
+        /* Now "reboot" */
+        fail_if(!boot_manager_set_uname(m, "4.2.1-121.kvm"), "Failed to simulate reboot");
+
+        /* Grab new kernels */
+        post_kernels = boot_manager_get_kernels(m);
+        fail_if(!post_kernels, "Failed to find kernels after update");
+        fail_if(post_kernels->len != 1, "Available post kernels != 1");
+
+        /* Check running kernel */
+        running_kernel = boot_manager_get_running_kernel(m, post_kernels);
+        fail_if(!running_kernel, "Failed to find kernel post reboot");
+        fail_if(!streq(running_kernel->meta.version, "4.2.1"), "Running kernel is invalid");
+}
+END_TEST
+
+static Suite *core_suite(void)
+{
+        Suite *s = NULL;
+        TCase *tc = NULL;
+
+        s = suite_create("bootman_grub2");
+        tc = tcase_create("bootman_grub2_functions");
+        tcase_add_test(tc, bootman_grub2_get_boot_device);
+        tcase_add_test(tc, bootman_grub2_image);
+        tcase_add_test(tc, bootman_grub2_native);
+        tcase_add_test(tc, bootman_grub2_update_from_unknown);
+        suite_add_tcase(s, tc);
+
+        return s;
+}
+
+int main(void)
+{
+        Suite *s;
+        SRunner *sr;
+        int fail;
+        /* override test ops for legacy grub2 testing */
+        CbmBlkidOps blkid_ops = BlkidTestOps;
+        blkid_ops.probe_lookup_value = grub2_blkid_probe_lookup_value;
+
+        /* syncing can be problematic during test suite runs */
+        cbm_set_sync_filesystems(false);
+
+        /* Ensure that logging is set up properly. */
+        setenv("CBM_DEBUG", "1", 1);
+        cbm_log_init(stderr);
+
+        cbm_blkid_set_vtable(&blkid_ops);
+        cbm_system_set_vtable(&SystemTestOps);
+
+        s = core_suite();
+        sr = srunner_create(s);
+        srunner_run_all(sr, CK_VERBOSE);
+        fail = srunner_ntests_failed(sr);
+        srunner_free(sr);
+
+        if (fail > 0) {
+                return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+}
+
+/*
+ * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
+ *
+ * Local variables:
+ * c-basic-offset: 8
+ * tab-width: 8
+ * indent-tabs-mode: nil
+ * End:
+ *
+ * vi: set shiftwidth=8 tabstop=8 expandtab:
+ * :indentSize=8:tabSize=8:noTabs=true:
+ */


### PR DESCRIPTION
This (long awaited) PR adds GRUB2 loader support.
This is used when no other bootloader is found to be compatible, i.e. non GPT non UEFI systems.
Additionally we add some minor cleanups and documentation around CBM integration

The GRUB2 code has been tested by (at the time of unwriting) 4 Solus users and shown to be working with:

 - Encrypted LVM
 - "Standard" (no encryption) install
 - Separate /boot and non-separate /boot