### PR TITLE
Grub submenus

### DIFF
--- a/src/bootloaders/grub2.c
+++ b/src/bootloaders/grub2.c
@@ -32,6 +32,20 @@
 #include "writer.h"
 
 /**
+ * Wrap up all the essentials into one big struct to help modularize the
+ * functions.
+ */
+typedef struct Grub2Config {
+        CbmWriter *writer;
+        const CbmDeviceProbe *root_dev;
+        char *boot_dir;
+        const char *os_name;
+        const char *os_id;
+        bool is_separate;
+        bool submenu;
+} Grub2Config;
+
+/**
  * Inspired by/modelled on, /etc/grub.d/10_linux
  * Each CBM entry is a unique script, so there is no caching between multiple
  * entries.
@@ -46,6 +60,12 @@
                 printf '\t%s\\n' \"${prep_root}\"\n\
         fi\n\
 "
+
+/**
+ * Maintain a queue of kernels until we set_default, allowing us to build
+ * a single file vs multiple files
+ */
+static KernelArray *kernel_queue = NULL;
 
 /**
  * Form the full path to the GRUB2 configuration script
@@ -80,16 +100,162 @@ static inline char *grub2_get_boot_relative(void)
 
 bool grub2_init(__cbm_unused__ const BootManager *manager)
 {
+        kernel_queue = nc_array_new();
+        if (!kernel_queue) {
+                DECLARE_OOM();
+                abort();
+        }
         return true;
 }
 
 void grub2_destroy(__cbm_unused__ const BootManager *manager)
 {
+        if (kernel_queue) {
+                /* kernels pointers inside are not owned by the array */
+                nc_array_free(&kernel_queue, NULL);
+        }
 }
 
-bool grub2_install_kernel(const BootManager *manager, const Kernel *kernel)
+/**
+ * Push a pointer to the kernel into our queue for processing during set_default
+ */
+bool grub2_install_kernel(__cbm_unused__ const BootManager *manager, const Kernel *kernel)
+{
+        if (!nc_array_add(kernel_queue, (void *)kernel)) {
+                DECLARE_OOM();
+                abort();
+        }
+
+        return true;
+}
+
+/**
+ * This step only removes the old kernel config file, which is no longer used
+ * by the GRUB2 implementation.
+ * Thus, it serves as a migration step
+ */
+bool grub2_remove_kernel(const BootManager *manager, const Kernel *kernel)
 {
         if (!manager || !kernel) {
+                return false;
+        }
+        autofree(char) *conf_path = NULL;
+
+        conf_path = grub2_get_entry_path_for_kernel((BootManager *)manager, kernel);
+        if (nc_file_exists(conf_path) && unlink(conf_path) < 0) {
+                LOG_FATAL("grub2_remove_kernel: Failed to remove %s: %s",
+                          conf_path,
+                          strerror(errno));
+                return false;
+        }
+        return true;
+}
+
+/**
+ * Write out the menuentry for a single kernel
+ */
+bool grub2_write_kernel(const Grub2Config *config, const Kernel *kernel)
+{
+        if (!config || !kernel) {
+                return false;
+        }
+        /* Submenu uses two tabs */
+        const char *tab = config->submenu ? "\t\t" : "\t";
+        const char *root_tab = config->submenu ? "\t" : "";
+
+        /* Write the start of the entry
+         * e.g. menuentry 'Some Linux OS (4.4.9-12.lts)' --class some-linux-os --class gnu-linux
+         * --class gnu --class os
+         */
+        cbm_writer_append_printf(config->writer,
+                                 "echo \"%smenuentry '%s (%s-%d.%s)' --class %s --class gnu-linux "
+                                 "--class gnu --class os",
+                                 root_tab,
+                                 config->os_name,
+                                 kernel->meta.version,
+                                 kernel->meta.release,
+                                 kernel->meta.ktype,
+                                 config->os_id);
+
+        /* Finish it off with a unique menu ID and escape the bash variable */
+        cbm_writer_append_printf(config->writer,
+                                 " \\$menuentry_id_option '%s-%s-%d.%s' {\"\n",
+                                 config->os_id,
+                                 kernel->meta.version,
+                                 kernel->meta.release,
+                                 kernel->meta.ktype);
+
+        /* Load video, compatibility with 10_linux */
+        cbm_writer_append_printf(config->writer,
+                                 "%sif [ \"x$GRUB_GFXPAYLOAD_LINUX\" = x ]; then\n",
+                                 tab);
+        cbm_writer_append_printf(config->writer, "%s\techo \"\tload_video\"\n", tab);
+        cbm_writer_append_printf(config->writer, "%sfi\n", tab);
+
+        /* Always load gzio */
+        cbm_writer_append_printf(config->writer, "echo \"%sinsmod gzio\"\n", tab);
+
+        const char *cache = GRUB2_10LINUX_CACHE;
+        cbm_writer_append(config->writer, cache);
+
+        /* Add the main loader lines */
+        cbm_writer_append_printf(config->writer,
+                                 "echo \"%secho 'Loading %s %s ...'\"\n",
+                                 tab,
+                                 config->os_name,
+                                 kernel->meta.version);
+        if (config->is_separate) {
+                cbm_writer_append_printf(config->writer,
+                                         "echo \"%slinux /%s root=UUID=%s ",
+                                         tab,
+                                         kernel->target.legacy_path,
+                                         config->root_dev->uuid);
+        } else {
+                cbm_writer_append_printf(config->writer,
+                                         "echo \"%slinux %s/%s root=UUID=%s ",
+                                         tab,
+                                         BOOT_DIRECTORY, /* i.e. /boot */
+                                         kernel->target.legacy_path,
+                                         config->root_dev->uuid);
+        }
+
+        if (config->root_dev->luks_uuid) {
+                cbm_writer_append_printf(config->writer,
+                                         "rd.luks.uuid=%s ",
+                                         config->root_dev->luks_uuid);
+        }
+
+        /* Finish it off with the command line options */
+        cbm_writer_append_printf(config->writer, "%s\"\n", kernel->meta.cmdline);
+
+        /* Optional initrd */
+        if (kernel->target.initrd_path) {
+                cbm_writer_append_printf(config->writer,
+                                         "echo \"%secho 'Loading initial ramdisk'\"\n",
+                                         tab);
+                if (config->is_separate) {
+                        cbm_writer_append_printf(config->writer,
+                                                 "echo \"%sinitrd /%s\"\n",
+                                                 tab,
+                                                 kernel->target.initrd_path);
+                } else {
+                        cbm_writer_append_printf(config->writer,
+                                                 "echo \"%sinitrd %s/%s\"\n",
+                                                 tab,
+                                                 BOOT_DIRECTORY, /* i.e. /boot */
+                                                 kernel->target.initrd_path);
+                }
+        }
+
+        /* Finalize the entry */
+        cbm_writer_append_printf(config->writer, "echo \"%s}\"\n\n", root_tab);
+
+        return true;
+}
+
+static bool grub2_write_config(const BootManager *manager, const Kernel *default_kernel)
+{
+        if (!manager) {
                 return false;
         }
 
@@ -103,16 +269,17 @@ bool grub2_install_kernel(const BootManager *manager, const Kernel *kernel)
         autofree(char) *boot_dir = NULL;
         const char *prefix = NULL;
         bool is_separate;
+        Grub2Config config = { 0 };
+        bool wrote_submenu = false;
 
         if (!cbm_writer_open(writer)) {
                 return false;
         }
 
         prefix = boot_manager_get_prefix((BootManager *)manager);
-
         root_dev = boot_manager_get_root_device((BootManager *)manager);
         if (!root_dev) {
-                LOG_FATAL("Root device unknown, this should never happen! %s", kernel->source.path);
+                LOG_FATAL("Root device unknown, this should never happen!");
                 return false;
         }
 
@@ -126,84 +293,81 @@ bool grub2_install_kernel(const BootManager *manager, const Kernel *kernel)
         cbm_writer_append(writer, "#!/bin/bash\nset -e\n");
         cbm_writer_append(writer, ". \"/usr/share/grub/grub-mkconfig_lib\"\n");
 
-        /* Write the start of the entry
-         * e.g. menuentry 'Some Linux OS (4.4.9-12.lts)' --class some-linux-os --class gnu-linux
-         * --class gnu --class os
+        /* Share our bits with grub2_write_kernel */
+        config = (Grub2Config){
+                .writer = writer,
+                .root_dev = root_dev,
+                .boot_dir = boot_dir,
+                .os_name = os_name,
+                .os_id = os_id,
+                .is_separate = is_separate,
+                .submenu = false,
+        };
+
+        /* Try to select a default kernel for update situations whereby CBM
+         * has been newly introduced, to ensure a /vmlinuz link
          */
-        cbm_writer_append_printf(
-            writer,
-            "echo \"menuentry '%s (%s-%d.%s)' --class %s --class gnu-linux --class gnu --class os",
-            os_name,
-            kernel->meta.version,
-            kernel->meta.release,
-            kernel->meta.ktype,
-            os_id);
-        /* Finish it off with a unique menu ID and escape the bash variable */
-        cbm_writer_append_printf(writer,
-                                 " \\$menuentry_id_option '%s-%s-%d.%s' {\"\n",
-                                 os_id,
-                                 kernel->meta.version,
-                                 kernel->meta.release,
-                                 kernel->meta.ktype);
-
-        /* Load video, compatibility with 10_linux */
-        cbm_writer_append(writer, "\tif [ \"x$GRUB_GFXPAYLOAD_LINUX\" = x ]; then\n");
-        cbm_writer_append(writer, "\t\techo \"\tload_video\"\n");
-        cbm_writer_append(writer, "\tfi\n");
-
-        /* Always load gzio */
-        cbm_writer_append(writer, "echo \"\tinsmod gzio\"\n");
-
-        const char *cache = GRUB2_10LINUX_CACHE;
-        cbm_writer_append(writer, cache);
-
-        /* Add the main loader lines */
-        cbm_writer_append_printf(writer,
-                                 "echo \"\techo 'Loading %s %s ...'\"\n",
-                                 os_name,
-                                 kernel->meta.version);
-        if (is_separate) {
-                cbm_writer_append_printf(writer,
-                                         "echo \"\tlinux /%s root=UUID=%s ",
-                                         kernel->target.legacy_path,
-                                         root_dev->uuid);
-        } else {
-                cbm_writer_append_printf(writer,
-                                         "echo \"\tlinux %s/%s root=UUID=%s ",
-                                         BOOT_DIRECTORY, /* i.e. /boot */
-                                         kernel->target.legacy_path,
-                                         root_dev->uuid);
+        if (!default_kernel && kernel_queue->len == 1) {
+                default_kernel = nc_array_get(kernel_queue, 0);
         }
 
-        if (root_dev->luks_uuid) {
-                cbm_writer_append_printf(writer, "rd.luks.uuid=%s ", root_dev->luks_uuid);
-        }
-
-        /* Finish it off with the command line options */
-        cbm_writer_append_printf(writer, "%s\"\n", kernel->meta.cmdline);
-
-        /* Optional initrd */
-        if (kernel->target.initrd_path) {
-                cbm_writer_append(writer, "echo \"\techo 'Loading initial ramdisk'\"\n");
-                if (is_separate) {
-                        cbm_writer_append_printf(writer,
-                                                 "echo \"\tinitrd /%s\"\n",
-                                                 kernel->target.initrd_path);
-                } else {
-                        cbm_writer_append_printf(writer,
-                                                 "echo \"\tinitrd %s/%s\"\n",
-                                                 BOOT_DIRECTORY, /* i.e. /boot */
-                                                 kernel->target.initrd_path);
+        /* Handle default kernel first always */
+        if (default_kernel) {
+                /* Attempt to clean out old files in migration, not fatal */
+                if (!grub2_remove_kernel(manager, default_kernel)) {
+                        LOG_ERROR("Failed to remove old kernel files for %s: %s",
+                                  default_kernel->target.legacy_path,
+                                  strerror(errno));
+                }
+                if (!grub2_write_kernel(&config, default_kernel)) {
+                        LOG_FATAL("Unable to write kernel config for %s",
+                                  default_kernel->target.legacy_path);
+                        return false;
+                }
+                /* Have a default kernel and more than one kernel, use submenus */
+                if (kernel_queue->len > 1) {
+                        config.submenu = true;
                 }
         }
 
-        /* Finalize the entry */
-        cbm_writer_append(writer, "echo \"}\"\n");
+        /* For every kernel write out a menuentry */
+        for (uint16_t i = 0; i < kernel_queue->len; i++) {
+                const Kernel *k = nc_array_get(kernel_queue, i);
+                if (default_kernel && k == default_kernel) {
+                        continue;
+                }
+
+                if (config.submenu && !wrote_submenu) {
+                        cbm_writer_append_printf(writer,
+                                                 "echo \"submenu '%s (alternative boot entries)'",
+                                                 os_name);
+                        /* Finish it off with a unique menu ID and escape the bash variable */
+                        cbm_writer_append_printf(writer,
+                                                 " \\$menuentry_id_option '%s-cbm-submenu' {\"\n",
+                                                 KERNEL_NAMESPACE);
+                        wrote_submenu = true;
+                }
+
+                /* Attempt to clean out old files in migration, not fatal */
+                if (!grub2_remove_kernel(manager, k)) {
+                        LOG_ERROR("Failed to remove old kernel files for %s: %s",
+                                  k->target.legacy_path,
+                                  strerror(errno));
+                }
+                if (!grub2_write_kernel(&config, k)) {
+                        LOG_FATAL("Unable to write kernel config for %s", k->target.legacy_path);
+                        return false;
+                }
+        }
+
+        if (wrote_submenu) {
+                /* Finalize the submenu */
+                cbm_writer_append(writer, "echo \"}\"\n\n");
+        }
 
         cbm_writer_close(writer);
 
-        conf_path = grub2_get_entry_path_for_kernel((BootManager *)manager, kernel);
-
+        conf_path = string_printf("%s/etc/grub.d/10_%s", prefix, KERNEL_NAMESPACE);
         /* If our new config matches the old config, just return. */
         if (file_get_text(conf_path, &old_conf)) {
                 if (streq(old_conf, writer->buffer)) {
@@ -219,39 +383,20 @@ bool grub2_install_kernel(const BootManager *manager, const Kernel *kernel)
         }
 
         if (!file_set_text(conf_path, writer->buffer)) {
-                LOG_FATAL("Failed to create loader entry for: %s [%s]",
-                          kernel->source.path,
-                          strerror(errno));
+                LOG_FATAL("Failed to create loader entry for: %s", strerror(errno));
                 return false;
         }
 
         /* Ensure it's executable */
         if (chmod(conf_path, 00755) != 0) {
                 LOG_FATAL("Failed to mark loader entry as executable: %s [%s]",
-                          kernel->source.path,
+                          conf_path,
                           strerror(errno));
                 return false;
         }
 
         cbm_sync();
 
-        return true;
-}
-
-bool grub2_remove_kernel(const BootManager *manager, const Kernel *kernel)
-{
-        if (!manager || !kernel) {
-                return false;
-        }
-        autofree(char) *conf_path = NULL;
-
-        conf_path = grub2_get_entry_path_for_kernel((BootManager *)manager, kernel);
-        if (nc_file_exists(conf_path) && unlink(conf_path) < 0) {
-                LOG_FATAL("grub2_remove_kernel: Failed to remove %s: %s",
-                          conf_path,
-                          strerror(errno));
-                return false;
-        }
         return true;
 }
 
@@ -298,6 +443,12 @@ bool grub2_set_default_kernel(const BootManager *manager, const Kernel *default_
                 LOG_FATAL("grub2_set_default_kernel: Failed to mkdir %s: %s",
                           grub_dir,
                           strerror(errno));
+                return false;
+        }
+
+        /* Write the grub configuration */
+        if (!grub2_write_config(manager, default_kernel)) {
+                LOG_FATAL("Failed to write GRUB2 configuration: %s", strerror(errno));
                 return false;
         }
 


### PR DESCRIPTION
This change allows CBM to dynamically use submenus, via a single GRUB2 config file
When only one kernel is known, a normal menu is used. Likewise, we do the same for the default kernel.
Anything else then lives in a submenu for alternative boot entries